### PR TITLE
fix build problem

### DIFF
--- a/qanary_component-smaph-erd/docker/Dockerfile
+++ b/qanary_component-smaph-erd/docker/Dockerfile
@@ -18,6 +18,6 @@ ADD smaph-config.xml smaph-config.xml
 ENTRYPOINT ["mvn", "-Djetty.port=9090", "jetty:run"]
 
 VOLUME /tmp
-ADD qa.smaph-erd-0.0.1.jar app.jar
+ADD qa.smaph-erd-1.0.0.jar app.jar
 RUN sh -c 'touch /app.jar'
 ENTRYPOINT ["java", "-server", "-Xms256M", "-Xmx512M", "-XX:MaxDirectMemorySize=256M", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]


### PR DESCRIPTION
[ERROR] Failed to execute goal com.spotify:docker-maven-plugin:0.4.10:build (build-image) on project qa.smaph-erd: Exception caught: ADD failed: stat /var/lib/docker/tmp/docker-builder512498411/qa.smaph-erd-0.0.1.jar: no such file or directory -> [Help 1]