### PR TITLE
Update Archetype

### DIFF
--- a/qanary_component-archetype/src/main/resources/archetype-resources/Dockerfile
+++ b/qanary_component-archetype/src/main/resources/archetype-resources/Dockerfile
@@ -1,7 +1,8 @@
-FROM openjdk:8-jre
 
-ENTRYPOINT ["/usr/local/openjdk-8/bin/java", "-jar", "/usr/share/qanary-components/qanary-service.jar"]
+FROM openjdk:11                                                                                                                                                                                                                             
 
 # Add the service itself
 ARG JAR_FILE
-ADD target/${JAR_FILE} /usr/share/qanary-components/qanary-service.jar
+ADD target/${JAR_FILE} /qanary-service.jar
+
+ENTRYPOINT ["java", "-jar", "/qanary-service.jar"]

--- a/qanary_component-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/qanary_component-archetype/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
 		<!-- Replace the name of the docker image to be generated -->
 		<!-- if there is an error demanding a lower-case name, then you picked 
 			a artifactId not following the naming conventions, (c.f., https://maven.apache.org/guides/mini/guide-naming-conventions.html) -->
-		<docker.image.name>${artifactId}</docker.image.name>
+		<docker.image.name>${artifactId.toLowerCase()}</docker.image.name>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 	</properties>
 

--- a/qanary_component-archetype/src/main/resources/archetype-resources/src/main/resources/config/application.properties
+++ b/qanary_component-archetype/src/main/resources/archetype-resources/src/main/resources/config/application.properties
@@ -6,9 +6,15 @@
 server.port=5555
 spring.application.name=${classname}
 spring.application.description=${spring.application.name} is a Qanary component
+
 # Update the URL of the Qanary pipeline
 spring.boot.admin.url=http://localhost:8080
 spring.boot.admin.client.url=${spring.boot.admin.url}
+
+#Service url
+spring.boot.admin.client.instance.service-base-url=http://localhost:${server.port}
+
+
 
 # log level definitions
 # change logging level in production


### PR DESCRIPTION
Updating the Component-archetype to run with docker. The new components now:
- Runs with JDK 11
- Don't have problems with case-sensitive in the pom file
- Now the instances perform right at localhost