### PR TITLE
show Annotation count

### DIFF
--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>eu.wdaqua.qanary</groupId>
             <artifactId>qa.commons</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.3</version>
             <scope>compile</scope>
         </dependency>
 

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
@@ -6,6 +6,12 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.UUID;
 
+import eu.wdaqua.qanary.commons.QanaryUtils;
+import eu.wdaqua.qanary.exceptions.SparqlQueryFailed;
+import net.sf.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.slf4j.Logger;
@@ -15,12 +21,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
@@ -427,6 +428,60 @@ public class QanaryQuestionAnsweringController {
 				myQanaryMessage.getInGraph(), myQanaryMessage.getOutGraph(), qanaryConfigurator);
 
 		return myRun;
+	}
+
+	/**
+	 * get the number of annotations created by a component
+	 */
+	@RequestMapping(value = "/numberOfAnnotations/", method = RequestMethod.GET, produces = "application/json")
+	public ResponseEntity<?> getNumberOfAnnotationsForComponent(
+			@RequestParam String component,
+			@RequestParam String graph
+	) throws URISyntaxException {
+
+		JSONObject json = new JSONObject();
+		URI graphUri = URI.create(graph);
+
+		String sparqlGet ="" +
+				"PREFIX oa: <http://www.w3.org/ns/openannotation/core/>" +
+				"SELECT (COUNT(*) AS ?NumberOfAnnotations)" +
+				"(SAMPLE(STR(?componentname)) AS ?ComponentName)" +
+				"FROM <"+graph+">" +
+				"WHERE {    ?s oa:annotatedBy ?componentname .    " +
+				"FILTER REGEX(STR(?componentname), \""+component+"\") . " +
+				"}";
+
+		QanaryMessage qanaryMessage= new QanaryMessage( qanaryConfigurator.getEndpoint(), graphUri);
+		QanaryUtils qanaryUtils = new QanaryUtils(qanaryMessage);
+
+		try {
+			logger.info("fetching number of annotations with query: {}",sparqlGet);
+
+			ResultSet annotations = qanaryUtils.selectFromTripleStore(sparqlGet, this.qanaryConfigurator.getEndpoint().toString());
+			QuerySolution annotation = annotations.next();
+
+			int annotationCount = 0;
+			String componentUrl = null;
+
+			try {
+				annotationCount = annotation.get("NumberOfAnnotations").asLiteral().getInt();
+				componentUrl = annotation.get("ComponentName").asLiteral().getString();
+				logger.info("found {} annotations for component {} on graph {}",annotationCount,component,graph);
+			} catch (NullPointerException nullPointer) {
+				logger.info("No annotations were found for component {} on graph {}",component,graph);
+			}
+
+			json.put("annotationCount", annotationCount);
+			json.put("componentUrl", componentUrl);
+			json.put("usedGraph", graph);
+			json.put("usedQuery", sparqlGet);
+
+
+		} catch (SparqlQueryFailed queryFailed) {
+			logger.error(queryFailed.getMessage());
+		}
+
+		return new ResponseEntity<>(json, HttpStatus.OK);
 	}
 
 	/**

--- a/qanary_pipeline-template/src/main/resources/templates/lib/header.html
+++ b/qanary_pipeline-template/src/main/resources/templates/lib/header.html
@@ -46,10 +46,10 @@
     	margin-left: 1ex; 
     }
     input[type=text] { 
-                width:50%; 
+                width:50%;
                 display:block; 
                 margin-bottom:2ex; 
-                max-width:500px; 
+                max-width:500px;
                 font-size: 13pt; 
                 padding:5px;
                 border: 1px solid #999;
@@ -168,7 +168,7 @@
     	fill: #00bc7c
     }
     </style>
-    <script>
+    <script th:inline="javascript">
        	// TODO: move minimumNumberOfSelectedComponents to config
        	minimumNumberOfSelectedComponents = 1;
        	
@@ -202,15 +202,15 @@
                 });
 
                 $("#results").hide(); // hide results table
-                
+
                 // add AJAX action to form
                 $("#startForm").submit(function(event){
                 	event.preventDefault(); // prevent default action 
                 	$("#submit").attr("disabled", true); // disable button
                 	$("#submit").addClass("inprogress"); // change cursor
                 	$("#results").slideUp(500); // hide last results with animation
-                	
-                	$.ajax({
+                    removeAnnotationCount(); // clear old annotation count values
+                    $.ajax({
                 		url : $(this).attr("action"), // get action url
                 		type: $(this).attr("method"), //get method
                 		data: $(this).serialize() // encode form elements 
@@ -224,6 +224,7 @@
                 		$("#outGraph").html(response.outGraph);
                     	$("#results").slideDown("fast"); // show results with animation
                     	$("#results").show();
+                        getNumberOfAnnotations(response.outGraph); // get new number of annotations
                 	}).error(function (jqXHR) {
                         $("#submit").attr("disabled", false); // reactivate button
                         $("#submit").removeClass("inprogress");
@@ -231,6 +232,39 @@
                 	});
                 });
         });
+
+        // remove any AnnotationCount components so that props can be updated correctly
+        function removeAnnotationCount() {
+            /*<![CDATA[*/
+            let components = [[${componentList}]]
+            for (i = 0; i < components.length; i++) {
+                let element = document.getElementById("annotationcount"+components[i]);
+                if(element){
+                    ReactDOM.unmountComponentAtNode(element);
+                }
+            }
+            /*]]>*/
+        }
+
+        // mount individual AnnotationCount to every component checklist item
+        function getNumberOfAnnotations(graph) {
+            console.log(graph)
+            /*<![CDATA[*/
+            let components = [[${componentList}]]
+            for (i = 0; i < components.length; i++) {
+                console.log(components[i]);
+                console.log(graph)
+                props = {
+                    component: components[i],
+                    graph: graph,
+                    fetched: false,
+                    annotationID: ("annotationcount"+components[i])
+                }
+                let annotationElement = e(AnnotationCount,props)
+                ReactDOM.render(annotationElement, document.getElementById("annotationcount"+components[i]));
+            }
+            /*]]>*/
+        }
         
         function checkInputAndOptionallyDisableSubmitButton(buttonID){
         	// disable button if the minimum number of components was not activated or question was not given

--- a/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
+++ b/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
@@ -12,7 +12,8 @@
 	                        <li th:each="component : ${componentList}">
 	                        	<input type="checkbox" name="componentlist[]" th:id="'componentlist'+${component}" th:value="${component}" />
                                 <label th:for="'componentlist'+${component}" th:title="'activate '+${component}+' for the QA pipeline'" th:text="${component}" />
-                        	</li>
+                                <span th:id="'annotationcount'+${component}"></span>
+                            </li>
                         </ul>
                 	</div>
 				</div>

--- a/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
+++ b/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
@@ -10,7 +10,7 @@
         <h1>Start a QA process with a new textual question</h1>
         <form id="startForm" action="/startquestionansweringwithtextquestion" method="POST">
 		        <div th:replace="lib/reusableforms::textquestioninput"/>
-				<div th:include="lib/reusableforms::componentlistcheckboxes"/>
+				<div th:include="lib/reusableforms::componentlistcheckboxes" />
                 <button id="submit">start Question Answering process provided by your configured Qanary pipeline <i class="fa fa-rocket"></i></button>               
         </form>
         <div id="results">
@@ -49,9 +49,68 @@
         	<h2>SPARQL query editor</h2>
 			<div id="yasgui"></div>
 		</div>
- 		<div th:replace="lib/footer"/>        
+ 		<div th:replace="lib/footer"/>
+		<!-- load React -->
+		<script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
+		<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
 </body>
 	<script th:inline="javascript">
+
+		const e = React.createElement;
+
+		/* fetches an object containing the number of annotations created by a component on a specified graph
+		* only annotationCount is rendered, but attributes
+		*   usedGraph,
+		*   componentUrl and
+		*   used query
+		* may also be accessed
+		 */
+		class AnnotationCount extends React.Component {
+			constructor(props) {
+				super(props);
+				this.state = {
+					response: [],
+					count: 0,
+					fetched: this.props.fetched
+				}
+				console.log(this.props)
+			}
+
+			callBackend() {
+				let graph = this.props.graph
+				let component = this.props.component
+
+				let requestString = "http://localhost:8080/numberOfAnnotations/?component=" + component + "&graph=" + graph;
+
+				fetch(requestString).then(response => {
+					if (response.status == 500) {
+						this.setState({count: 0, response: response, fetched: true})
+						return Promise.reject();
+					}
+					return response.json();
+				}).then(
+						data => {
+							this.setState({count: data.annotationCount, response: data, fetched: true})
+							console.log(this.state.response);
+						}
+				).catch(function (error) {
+					console.log(error)
+				})
+			}
+
+			render() {
+				if (this.state.fetched) {
+					// don't perform another backend call
+					console.log("data already fetched")
+				} else {
+					this.callBackend();
+					console.log("fetching data")
+
+				}
+				// display only the number of annotations
+				return "(created "+this.state.count+" annotations)"
+			}
+		}
 
 		const yasgui = new Yasgui(document.getElementById("yasgui"), {
 				copyEndpointOnNewTab: false,


### PR DESCRIPTION
On `startquestionansweringwithtextquestion` for every component selected for the pipeline process the number of created Annotations is shown.

`qanary_pipeline-template` uses version 2.0.3 of qa.commons following [commit 186c06eb2906b7d8a11513a029f6192b02b20872](https://github.com/WDAqua/Qanary/commit/186c06eb2906b7d8a11513a029f6192b02b20872#diff-8dd8750b189dfef69bde0ca1c366d927).

