### PR TITLE
(docker): update pipeline and config-ui versions

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
 PIPELINE_HOST=localhost
 PIPELINE_PORT=8080
 PIPELINE_NAME=qa.pipeline
-PIPELINE_VERSION=2.1.5
-PIPELINE_IMAGE=qapipeline
+PIPELINE_VERSION=2.1.7
+PIPELINE_IMAGE=qanary/qanary-pipeline:2.1.7
 
 UI_PORT=8081
-UI_IMAGE=configuration-ui
-UI_VERSION=latest
+UI_IMAGE=qanary/qanary-configuration-frontend:0.1.0
+UI_VERSION=0.1.0

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>qa.pipeline</artifactId>
 	<groupId>eu.wdaqua.qanary</groupId>
-	<version>2.1.6</version>
+	<version>2.1.7</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Following the recently added feature (question URIs) the `docker-compose.yml` file has to use a newer version for Qanary pipeline.
Configuration UI now uses version 0.1.0 instead of latest.