### PR TITLE
Make configuration UI connection configurable 

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
 PIPELINE_HOST=localhost
 PIPELINE_PORT=8080
 PIPELINE_NAME=qa.pipeline
-PIPELINE_VERSION=2.1.7
-PIPELINE_IMAGE=qanary/qanary-pipeline
+PIPELINE_VERSION=2.1.5
+PIPELINE_IMAGE=qapipeline
 
 UI_PORT=8081
-UI_IMAGE=qanary/qanary-pipeline-configuration
-UI_VERSION=1.0.0
+UI_IMAGE=configuration-ui
+UI_VERSION=latest

--- a/.env
+++ b/.env
@@ -1,9 +1,9 @@
 PIPELINE_HOST=localhost
 PIPELINE_PORT=8080
 PIPELINE_NAME=qa.pipeline
-PIPELINE_VERSION=2.1.5
-PIPELINE_IMAGE=qapipeline
+PIPELINE_VERSION=2.1.7
+PIPELINE_IMAGE=qanary/qanary-pipeline
 
 UI_PORT=8081
-UI_IMAGE=configuration-ui
-UI_VERSION=latest
+UI_IMAGE=qanary/qanary-pipeline-configuration
+UI_VERSION=1.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,9 @@ services:
   config-ui:
     build:
       context: ./qanary-configuration-frontend
-      args:
-        REACT_APP_HOST: ${PIPELINE_HOST}
-        REACT_APP_PORT: ${PIPELINE_PORT}
     image: ${UI_IMAGE}:${UI_VERSION}
     ports:
-      - "${UI_PORT}:80"
+      - "${UI_PORT}:5000"
+    environment:
+            - "REACT_APP_HOST=${PIPELINE_HOST}"
+            - "REACT_APP_PORT=${PIPELINE_PORT}"

--- a/qanary-configuration-frontend/.env
+++ b/qanary-configuration-frontend/.env
@@ -1,2 +1,3 @@
+# Default variables for connection to Qanary pipeline
 REACT_APP_HOST=localhost
 REACT_APP_PORT=8080

--- a/qanary-configuration-frontend/Dockerfile
+++ b/qanary-configuration-frontend/Dockerfile
@@ -1,25 +1,15 @@
-# build
+FROM node:9.4
 
-FROM node:13.12.0-alpine as build
-WORKDIR /app
-ENV PATH /app/node_modules/.bin:$PATH
-COPY package.json ./
-COPY package-lock.json ./
-RUN npm ci
-RUN npm install react-scripts@3.4.1 -g
-COPY . ./
+WORKDIR /usr/share/app
 
-ARG REACT_APP_HOST
-ARG REACT_APP_PORT
+EXPOSE 5000 
 
-ENV REACT_APP_HOST=$REACT_APP_HOST
-ENV REACT_APP_PORT=$REACT_APP_PORT
+RUN npm install -g serve
 
-RUN npm run build
+COPY . .
 
-# production
+RUN npm install
 
-FROM nginx:stable-alpine
-COPY --from=build /app/build /usr/share/nginx/html
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+RUN chmod +x /usr/share/app/run-app.sh
+
+CMD ["sh", "/usr/share/app/run-app.sh"]

--- a/qanary-configuration-frontend/package-lock.json
+++ b/qanary-configuration-frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qanary-configuration-frontend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,65 +30,184 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.6",
-        "@babel/helper-module-transforms": "^7.11.0",
-        "@babel/helpers": "^7.10.4",
-        "@babel/parser": "^7.11.5",
-        "@babel/template": "^7.10.4",
-        "@babel/traverse": "^7.11.5",
-        "@babel/types": "^7.11.5",
+        "@babel/generator": "^7.12.10",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.11.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+          "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
           "requires": {
-            "@babel/types": "^7.11.5",
+            "@babel/types": "^7.12.11",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
-        "@babel/parser": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
-        },
-        "@babel/traverse": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+        "@babel/helper-function-name": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+          "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
           "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.11.5",
-            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-get-function-arity": "^7.12.10",
+            "@babel/template": "^7.12.7",
+            "@babel/types": "^7.12.11"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+          "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+          "requires": {
+            "@babel/types": "^7.12.10"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+          "integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+          "requires": {
+            "@babel/types": "^7.12.7"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+          "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+          "requires": {
+            "@babel/types": "^7.12.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+          "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.12.1",
+            "@babel/helper-replace-supers": "^7.12.1",
+            "@babel/helper-simple-access": "^7.12.1",
             "@babel/helper-split-export-declaration": "^7.11.0",
-            "@babel/parser": "^7.11.5",
-            "@babel/types": "^7.11.5",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.12.1",
+            "@babel/types": "^7.12.1",
             "lodash": "^4.17.19"
           }
         },
-        "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.12.10",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+          "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
+            "@babel/types": "^7.12.10"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+          "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.12.7",
+            "@babel/helper-optimise-call-expression": "^7.12.10",
+            "@babel/traverse": "^7.12.10",
+            "@babel/types": "^7.12.11"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+          "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+          "requires": {
+            "@babel/types": "^7.12.1"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+        },
+        "@babel/helpers": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+          "integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.12.5",
+            "@babel/types": "^7.12.5"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+          "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+        },
+        "@babel/template": {
+          "version": "7.12.7",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+          "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.12.7",
+            "@babel/types": "^7.12.7"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+          "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+          "requires": {
+            "@babel/code-frame": "^7.12.11",
+            "@babel/generator": "^7.12.11",
+            "@babel/helper-function-name": "^7.12.11",
+            "@babel/helper-split-export-declaration": "^7.12.11",
+            "@babel/parser": "^7.12.11",
+            "@babel/types": "^7.12.12",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@babel/code-frame": {
+              "version": "7.12.11",
+              "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+              "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+              "requires": {
+                "@babel/highlight": "^7.10.4"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.12.11",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+              "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+              "requires": {
+                "@babel/types": "^7.12.11"
+              }
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.12.12",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
             "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }

--- a/qanary-configuration-frontend/package.json
+++ b/qanary-configuration-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qanary-configuration-frontend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",

--- a/qanary-configuration-frontend/run-app.sh
+++ b/qanary-configuration-frontend/run-app.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# set -o nounset \
+ #    -o errexit \
+   #  -o verbose \
+    # -o xtrace
+
+# override environment variables if provided as argument
+if [ $# -ne 0 ]; then
+    echo "-> overriding env with args ..."
+    for var in "$@"
+    do
+        export "$var"
+    done
+fi
+
+echo "-> ENV vars:"
+env | sort
+
+echo "-> User:"
+id
+
+echo "-> building app ..."
+npm run build --production
+
+echo "=> running app ..."
+exec serve -s build


### PR DESCRIPTION
When starting the Qanary configuration front end with docker the host and port of Qanary pipeline can be provided with 
`docker run -e REACT_APP_HOST=<host> -e REACT_APP_PORT=<port> qanary/qanary-configuration-frontend:1.0.0`.

or in `docker-compose.yml` as `environment:` parameter.

If no parameters are specified the UI uses the default values set in `qanary-configuration-frontend/.env`:
- REACT_APP_HOST=localhost
- REACT_APP_PORT=8080