### PR TITLE
Configurable ontology location

### DIFF
--- a/qanary_commons/pom.xml
+++ b/qanary_commons/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>eu.wdaqua.qanary</groupId>
 	<artifactId>qa.commons</artifactId>
-	<version>2.1.0</version>
+	<version>2.2.0</version>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/business/QanaryConfigurator.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/business/QanaryConfigurator.java
@@ -30,13 +30,15 @@ public class QanaryConfigurator {
 
 	private static final Logger logger = LoggerFactory.getLogger(QanaryConfigurator.class);
 	private final RestTemplate restTemplate;
-	// default configuration defined in the currently used in application
+	// default configuration defined in the currently used application
 	// context (e.g., defined in application.properties)
 	private List<String> defaultComponentNames;
 
 	private final int port;
 	private final String host;
 	private final URI endpoint;
+
+	private final URI qanaryOntology;
 
 	// parameter required to create the correct triplestore endpoint, particularly
 	// due to Stardog v5+
@@ -48,7 +50,8 @@ public class QanaryConfigurator {
 			String serverhost, //
 			int serverport, //
 			URI triplestoreendpoint, //
-			TriplestoreEndpointIdentifier myTriplestoreEndpointIdentifier //
+			URI qanaryOntology, //
+			TriplestoreEndpointIdentifier myTriplestoreEndpointIdentifier 
 	) {
 		this.restTemplate = restTemplate;
 		this.myTriplestoreEndpointIdentifier = myTriplestoreEndpointIdentifier;
@@ -56,6 +59,7 @@ public class QanaryConfigurator {
 		this.port = serverport;
 		this.host = serverhost;
 		this.endpoint = triplestoreendpoint;
+		this.qanaryOntology = qanaryOntology;
 
 		logger.warn("make sure the triplestore is available at {}", triplestoreendpoint);
 	}
@@ -119,6 +123,10 @@ public class QanaryConfigurator {
 		result.endQuestionAnswering();
 		logger.info("callServices finished: {}", result);
 		return result;
+	}
+
+	public URI getQanaryOntology() {
+		return this.qanaryOntology;
 	}
 
 	public int getPort() {

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
@@ -12,6 +12,7 @@ import org.apache.jena.query.ResultSet;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -94,13 +95,11 @@ public class QanaryQuestion<T> {
 		loadTripleStore(sparqlquery, qanaryConfigurator);
 
 		// Load the Qanary Ontology using the permanent GitHub location
-		// be aware that
-		// https://raw.githubusercontent.com/WDAqua/QAOntology/master/qanary.owl does
-		// not work due to header issues on behalf of GitHub
+		// specified in application.properties
 		sparqlquery = "" //
-				+ "LOAD <https://rawcdn.githack.com/WDAqua/QAOntology/6d25ebc8970b93452b5bb970a8e2f526be9841a5/qanary.owl> " //
+				+ "LOAD <"+qanaryConfigurator.getQanaryOntology()+"> " //
 				+ "INTO GRAPH " + namedGraphMarker;
-		logger.warn("SPARQL query: {}", sparqlquery);
+		logger.info("SPARQL query: {}", sparqlquery);
 		loadTripleStore(sparqlquery, qanaryConfigurator);
 
 		// Prepare the question, answer and dataset objects

--- a/qanary_commons/src/test/java/qa/commons/PriorConversationTest.java
+++ b/qanary_commons/src/test/java/qa/commons/PriorConversationTest.java
@@ -35,6 +35,7 @@ class PriorConversationTest {
                     null,
                     0,
                     null,
+                    null,
                     null);
 
             // when QanaryQuestion is instantiated

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>qa.pipeline</artifactId>
 	<groupId>eu.wdaqua.qanary</groupId>
-	<version>2.3.0</version>
+	<version>2.4.0</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -17,7 +17,7 @@
 		<java.version>11</java.version>
 		<spring-boot-admin.version>2.1.6</spring-boot-admin.version>
 		<qanary.version>[2.1.0,3.0.0)</qanary.version>
-		<qanary.version>2.1.0</qanary.version>
+		<qanary.version>2.2.0</qanary.version>
 		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 		<docker.image.prefix>qanary</docker.image.prefix>
 		<docker.image.name>qapipeline</docker.image.name>

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryPipeline.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryPipeline.java
@@ -74,6 +74,7 @@ public class QanaryPipeline {
 				qanaryPipelineConfiguration.getHost(), // from config
 				qanaryPipelineConfiguration.getPort(), // from config
 				qanaryPipelineConfiguration.getTriplestoreAsURI(), // from config
+				qanaryPipelineConfiguration.getQanaryOntologyAsURI(), // from config
 				myTriplestoreEndpointIdentifier //
 		);
 	}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
@@ -44,7 +44,7 @@ public class QanaryPipelineConfiguration {
 			"server", //
 			"spring" //
 	};
-	private final String[] requiredParameterNames = { "qanary.triplestore", "server.host", "server.port" };
+	private final String[] requiredParameterNames = { "qanary.triplestore", "server.host", "server.port", "qanary.ontology"};
 
 	public QanaryPipelineConfiguration(@Autowired Environment environment) {
 		this.environment = environment;
@@ -178,6 +178,11 @@ public class QanaryPipelineConfiguration {
 		}
 	}
 
+	/**
+	 * required attribute
+	 * 
+	 * @return
+	 */
 	public URI getTriplestoreAsURI() throws TripleStoreNotProvided {
 		try {
 			return new URI(getTriplestore());
@@ -186,6 +191,15 @@ public class QanaryPipelineConfiguration {
 					"triplestore value '" + getTriplestore() + "' was no URI.\n(error: " + e.getMessage() + ")");
 		}
 	}
+
+	public URI getQanaryOntologyAsURI() {
+		try {
+			return new URI(this.getProperty("qanary.ontology"));
+		} catch (Exception e) {
+			throw new MissingRequiredConfiguration("qanary.ontology");
+		}
+	}
+
 
 	/**
 	 * default value is System.getProperty("user.dir") if configuration is not

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
@@ -38,7 +38,8 @@ public class QanaryPipelineConfiguration {
 			"server.port", //
 			"qanary.triplestore", //
 			"qanary.questions.directory", //
-			"qanary.components" };
+			"qanary.components", //
+			"qanary.ontology"};
 	private final String[] debugPropertiesPrefixesToBeShowOnStartup = { //
 			"qanary", //
 			"server", //

--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -56,6 +56,12 @@ qanary.triplestore.stardog5=true
 ### then the spring.boot.admin.url needs to be defined
 # example: spring.boot.admin.url=http://localhost:8080
 
+### specify the permanent GitHub location to load the Qanary Ontology
+### be aware that
+### https://raw.githubusercontent.com/WDAqua/QAOntology/master/qanary.owl does
+### not work due to header issues on behalf of GitHub
+qanary.ontology=https://rawcdn.githack.com/WDAqua/QAOntology/6d25ebc8970b93452b5bb970a8e
+
 ### if the Qanary pileine is not used in an interactive mode, components to be used can be predefined 
 ### here (by names) 
 # example: qanary.components=FirstComponent,SecondComponent


### PR DESCRIPTION
Make the URL pointing to the OWL qa vocabulary configurable in `application.properties` or `application.local.properties`.