### PR TITLE
Fix Qanary Ontology Location in Properties

### DIFF
--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -60,7 +60,7 @@ qanary.triplestore.stardog5=true
 ### be aware that
 ### https://raw.githubusercontent.com/WDAqua/QAOntology/master/qanary.owl does
 ### not work due to header issues on behalf of GitHub
-qanary.ontology=https://rawcdn.githack.com/WDAqua/QAOntology/6d25ebc8970b93452b5bb970a8e
+qanary.ontology=https://rawcdn.githack.com/WDAqua/QAOntology/6d25ebc8970b93452b5bb970a8e/qanary.owl
 
 ### if the Qanary pileine is not used in an interactive mode, components to be used can be predefined 
 ### here (by names) 


### PR DESCRIPTION
Correct the ontology location specified in `application.properties` of `qanary_pipeline-template` s.t. it can be loaded into the triplestore.