### PR TITLE
changes for Gerbil QA

### DIFF
--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
@@ -545,8 +545,14 @@ public class QanaryQuestion<T> {
 	}
 
 	public String getSparqlResult() throws SparqlQueryFailed {
-		//TODO: this can throw index out of bounds if no query was annotated
-		return this.getSparqlResults().get(0).query;
+		// added try and catch to prevent indexOutOfBoundsException, returns empty String if no Query was found
+		String sparqlResult = "";
+		try {
+			sparqlResult = this.getSparqlResults().get(0).query;
+		} catch (IndexOutOfBoundsException e) {
+			logger.warn("No SPARQL Query found, index out of bounds");
+		}
+		return sparqlResult;
 	}
 
 	public String getJsonResult() throws SparqlQueryFailed {

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
@@ -572,7 +572,7 @@ public class QanaryQuestion<T> {
 				+ "}";
 		ResultSet resultset = qanaryUtil.selectFromTripleStore(sparql, this.getEndpoint().toString());
 
-		String sparqlAnnotation = null;
+		String sparqlAnnotation = "";
 		while (resultset.hasNext()) {
 			sparqlAnnotation = resultset.next().get("json").asLiteral().toString();
 		}

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
@@ -49,7 +49,7 @@ public class QanaryQuestion<T> {
 	private URI uriTextualRepresentation;
 	private URI uriAudioRepresentation;
 	private final URI namedGraph; // where the question is stored
-	private List<String> language;
+	private String language;
 	private List<String> knowledgeBase;
 
 	private QanaryConfigurator myQanaryConfigurator;
@@ -612,10 +612,10 @@ public class QanaryQuestion<T> {
 	 *
 	 * @param language
 	 */
-	public void setLanguageText(List<String> language) throws Exception {
+	public void setLanguageText(String language) throws Exception {
 		String part = "";
-		for (int i = 0; i < language.size(); i++) {
-			part += "?a oa:hasBody \"" + language.get(i) + "\" . ";
+		if (language != null && !language.isEmpty()) {
+			part = "?a oa:hasBody \"" + language + "\" . ";
 		}
 		String sparql = "" //
 				+ "PREFIX qa: <http://www.wdaqua.eu/qa#> " //
@@ -639,7 +639,7 @@ public class QanaryQuestion<T> {
 	/**
 	 * get the language of the question, enabled for feedback
 	 */
-	public List<String> getLanguage() throws Exception {
+	public String getLanguage() throws Exception {
 		if (this.language == null) {
 			String sparql = "" //
 					+ "PREFIX qa: <http://www.wdaqua.eu/qa#> " //
@@ -662,12 +662,16 @@ public class QanaryQuestion<T> {
 			ResultSet resultset = qanaryUtil.selectFromTripleStore(sparql, this.getEndpoint().toString());
 
 			int i = 0;
-			List<String> language = new ArrayList<>();
+			List<String> languageArray = new ArrayList<>();
+			String language = "";
 			while (resultset.hasNext()) {
-				language.add(resultset.next().get("uri").toString());
+				languageArray.add(resultset.next().get("uri").toString());
 				i++;
 			}
-			if (i > 1) {
+			if (i == 1) {
+				language = languageArray.get(0);
+			}
+			else if (i > 1) {
 				throw new Exception("More than 1 language (count: " + i + ") in graph " + this.getInGraph() + " at "
 						+ this.getEndpoint());
 			} else if (i == 0) {

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryQuestion.java
@@ -572,7 +572,8 @@ public class QanaryQuestion<T> {
 				+ "}";
 		ResultSet resultset = qanaryUtil.selectFromTripleStore(sparql, this.getEndpoint().toString());
 
-		String sparqlAnnotation = "";
+		// the default value has to be null to distinguish missing values from empty values
+		String sparqlAnnotation = null; 
 		while (resultset.hasNext()) {
 			sparqlAnnotation = resultset.next().get("json").asLiteral().toString();
 		}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryGerbilController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryGerbilController.java
@@ -9,6 +9,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -132,7 +134,7 @@ public class QanaryGerbilController {
 	public ResponseEntity<?> gerbil(
 			@RequestParam(value = "query", required = true) final String query,
             @PathVariable("components") final String componentsToBeCalled
-    ) throws URISyntaxException, SparqlQueryFailed {
+    ) throws URISyntaxException, Exception, SparqlQueryFailed, ParseException {
     	logger.info("Asked question: {}", query);
         logger.info("QA pipeline components: {}", componentsToBeCalled);
     	MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
@@ -146,31 +148,59 @@ public class QanaryGerbilController {
         @SuppressWarnings("rawtypes")
 		QanaryQuestion<?> myQanaryQuestion = new QanaryQuestion(myQanaryMessage);
         //Generates the following output
-    	/*{
- 		   "questions":[
- 		      "question":{
- 		         "answers":"...",
- 		         "language":[
- 		            {
- 		               "SPARQL":"..."
- 		            }
- 		         ]
- 		      }
- 		   ]
- 		}*/
+        /*{
+            "questions": [{
+                "question": [{
+                    "language": "en",   //(ISO 639-1)
+          			"string": "..."     //(textual representation of asked Question)
+          			    }],
+          		"query": {
+          		    "sparql": "..."     //(SPARQL Query constructed by QB component)
+                },
+          		"answers": [{"..."}]    //(Answers returned by QE component)
+            }]
+        }*/
+        // retrieve the content (question, SPARQL Query and answer)
+        // getTextualRepresentation needs Exception to be thrown
+        String language = "en";
+        String questionText = myQanaryQuestion.getTextualRepresentation();
+        String sparqlQueryString = myQanaryQuestion.getSparqlResult();      // returns empty String if no Query was found
+        String jsonAnswerString = myQanaryQuestion.getJsonResult();         // returns empty String if no answer was found
+
+        // create the question array and object and add the content
+        JSONArray questionDataArray = new JSONArray();
+        JSONObject questionData = new JSONObject();
+        questionData.put("language", language);
+        questionData.put("string", questionText);
+        questionDataArray.add(questionData);
+
+        // create the query object and add the content
+        JSONObject queryObj = new JSONObject();
+        queryObj.put("sparql", sparqlQueryString);
+
+        // transform the answer String to JSON, if an answer was found
+        JSONObject answersObj = new JSONObject();
+        if (jsonAnswerString.length() > 0) {
+            JSONParser parser = new JSONParser();
+            answersObj = (JSONObject) parser.parse(jsonAnswerString);
+        }
+
+        // create the answers array and add the content
+        JSONArray answersArray = new JSONArray();
+        answersArray.add(answersObj);
+
+        // create the wrapper object and the array and add all JSON to it
+        JSONArray questionsArray = new JSONArray();
+        JSONObject questionObject = new JSONObject();
+        questionObject.put("question", questionDataArray);
+        questionObject.put("query", queryObj);
+        questionObject.put("answers", answersArray);
+        questionsArray.add(questionObject);
+
+        // add all to the wrapper object
         JSONObject obj = new JSONObject();
-        JSONArray questions = new JSONArray();
-        JSONObject item = new JSONObject();
-        JSONObject question = new JSONObject();
-        JSONArray language = new JSONArray();
-        JSONObject sparql = new JSONObject();
-        sparql.put("SPARQL", myQanaryQuestion.getSparqlResult());
-    	language.add(sparql);
-    	question.put("answers", myQanaryQuestion.getJsonResult());
-    	question.put("language", language);
-    	item.put("question", question);
-    	questions.add(item);
-    	obj.put("questions", questions);
-    	return new ResponseEntity<JSONObject>(obj,HttpStatus.OK);
+        obj.put("questions", questionsArray);
+
+        return new ResponseEntity<JSONObject>(obj,HttpStatus.OK);
 	}
 }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryGerbilController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryGerbilController.java
@@ -192,7 +192,7 @@ public class QanaryGerbilController {
 
         // transform the answer String to JSON, if an answer was found
         JSONObject answersObj = new JSONObject();
-        if (jsonAnswerString.length() > 0) {
+        if (jsonAnswerString != null && jsonAnswerString.length() > 0) {
             JSONParser parser = new JSONParser();
             answersObj = (JSONObject) parser.parse(jsonAnswerString);
         }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
@@ -137,7 +137,7 @@ public class QanaryQuestionAnsweringController {
 	public ResponseEntity<?> startquestionansweringwithtextquestion(
 			@RequestParam(value = QanaryStandardWebParameters.QUESTION, required = true) final String question,
 			@RequestParam(value = QanaryStandardWebParameters.COMPONENTLIST, defaultValue = "") final List<String> componentsToBeCalled,
-			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final List<String> language, //
+			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final String language, //
 			@RequestParam(value = QanaryStandardWebParameters.TARGETDATA, defaultValue = "", required = false) final List<String> targetdata, //
 			@RequestParam(value = QanaryStandardWebParameters.PRIORCONVERSATION, defaultValue = "", required = false) final URI priorConversation//
 			) throws Exception {
@@ -181,7 +181,7 @@ public class QanaryQuestionAnsweringController {
 	public ResponseEntity<?> startquestionansweringwithaudioquestion(
 			@RequestParam(value = QanaryStandardWebParameters.QUESTION, required = true) final MultipartFile question,
 			@RequestParam(value = QanaryStandardWebParameters.COMPONENTLIST, defaultValue = "") final List<String> componentsToBeCalled, //
-			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final List<String> language, //
+			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final String language, //
 			@RequestParam(value = QanaryStandardWebParameters.TARGETDATA, defaultValue = "", required = false) final List<String> targetdata, //
 			@RequestParam(value = QanaryStandardWebParameters.PRIORCONVERSATION, defaultValue = "", required = false) final URI priorConversation//
 			) throws Exception {
@@ -272,7 +272,7 @@ public class QanaryQuestionAnsweringController {
 			@RequestParam(value = QanaryStandardWebParameters.AUDIOQUESTION, required = false) final MultipartFile audioquestion, //
 			@RequestParam(value = QanaryStandardWebParameters.GRAPH, defaultValue = "", required = false) final URI graph, //
 			@RequestParam(value = QanaryStandardWebParameters.COMPONENTLIST, defaultValue = "", required = false) final List<String> componentsToBeCalled, //
-			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final List<String> language, //
+			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final String language, //
 			@RequestParam(value = QanaryStandardWebParameters.TARGETDATA, defaultValue = "", required = false) final List<String> targetdata, //
 			@RequestParam(value = QanaryStandardWebParameters.PRIORCONVERSATION, defaultValue = "", required = false) final URI priorConversation//
 			) throws Exception {
@@ -307,7 +307,7 @@ public class QanaryQuestionAnsweringController {
 			@RequestParam(value = QanaryStandardWebParameters.AUDIOQUESTION, required = false) final MultipartFile audioquestion, //
 			@RequestParam(value = QanaryStandardWebParameters.GRAPH, defaultValue = "", required = false) final URI graph, //
 			@RequestParam(value = QanaryStandardWebParameters.COMPONENTLIST, defaultValue = "", required = false) final List<String> componentsToBeCalled, //
-			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final List<String> language, //
+			@RequestParam(value = QanaryStandardWebParameters.LANGUAGE, defaultValue = "", required = false) final String language, //
 			@RequestParam(value = QanaryStandardWebParameters.TARGETDATA, defaultValue = "", required = false) final List<String> targetdata, //
 			@RequestParam(value = QanaryStandardWebParameters.PRIORCONVERSATION, defaultValue = "", required = false) final URI priorConversation//
 			)
@@ -358,7 +358,7 @@ public class QanaryQuestionAnsweringController {
 	 * @throws Exception
 	 */
 	private QanaryQuestionAnsweringRun createOrUpdateAndRunQuestionAnsweringSystemHelper(URI graph, String question,
-			MultipartFile questionaudio, List<String> componentsToBeCalled, List<String> language,
+			MultipartFile questionaudio, List<String> componentsToBeCalled, String language,
 			List<String> targetdata, URI priorConversation) throws Exception {
 
 		// create a QanaryQuestion from given question and graph

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/RequestQuestionAnsweringProcess.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/RequestQuestionAnsweringProcess.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class RequestQuestionAnsweringProcess {
 	private String question;
 	private List<String> componentlist = new ArrayList<>();
-	private String language = "";
+	private String language = null;
 	private List<String> targetdata = new ArrayList<>();
 	private URI priorConversation;
 
@@ -71,7 +71,8 @@ public class RequestQuestionAnsweringProcess {
 		return "RequestQuestionAnsweringProcess " //
 				+ " -- question: \"" + getQuestion() + "\"" //
 				+ " -- componentList: " + Arrays.toString(getcomponentlist().toArray()) //
-				+ " -- priorConversation: " + getPriorConversation();
+				+ " -- priorConversation: " + getPriorConversation() // 
+				+ " -- language: " + getLanguage();
 	}
 
 }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/RequestQuestionAnsweringProcess.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/RequestQuestionAnsweringProcess.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class RequestQuestionAnsweringProcess {
 	private String question;
 	private List<String> componentlist = new ArrayList<>();
-	private List<String> language = new ArrayList<>();
+	private String language = "";
 	private List<String> targetdata = new ArrayList<>();
 	private URI priorConversation;
 
@@ -42,11 +42,11 @@ public class RequestQuestionAnsweringProcess {
 		this.componentlist = componentsToBeCalled;
 	}
 
-	public List<String> getLanguage() {
+	public String getLanguage() {
 		return language;
 	}
 
-	public void setLanguage(List<String> language) {
+	public void setLanguage(String language) {
 		this.language = language;
 	}
 

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryQuestionAnsweringControllerTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryQuestionAnsweringControllerTest.java
@@ -33,7 +33,7 @@ class QanaryQuestionAnsweringControllerTest {
     private MockMvc mvc;
 
     @Test
-    void testRequestQuestionAnsweringProcessToString() throws URISyntaxException {
+    void testRequestQuestionAnsweringProcessToStringWithoutLanguage() throws URISyntaxException {
         RequestQuestionAnsweringProcess qaProcess = new RequestQuestionAnsweringProcess();
 
         String question = "What is the real name of Batman";
@@ -46,10 +46,37 @@ class QanaryQuestionAnsweringControllerTest {
         qaProcess.setcomponentlist(componentList);
         qaProcess.setPriorConversation(priorConversation);
 
-        String expected = "RequestQuestionAnsweringProcess " +
-                " -- question: \"What is the real name of Batman\"" +
-                " -- componentList: [NED-DBpediaSpotlight, QueryBuilderSimpleRealNameOfSuperHero]" +
-                " -- priorConversation: urn:graph:806261d9-4601-4c8c-8603-926eee707c38";
+        String expected = "RequestQuestionAnsweringProcess " + // 
+                " -- question: \"What is the real name of Batman\"" + // 
+                " -- componentList: [NED-DBpediaSpotlight, QueryBuilderSimpleRealNameOfSuperHero]" + // 
+                " -- priorConversation: urn:graph:806261d9-4601-4c8c-8603-926eee707c38" + // 
+                " -- language: null";
+
+        String actual = qaProcess.toString();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testRequestQuestionAnsweringProcessToStringWithLanguage() throws URISyntaxException {
+        RequestQuestionAnsweringProcess qaProcess = new RequestQuestionAnsweringProcess();
+
+        String question = "What is the real name of Batman";
+        List<String> componentList = new ArrayList<>();
+        componentList.add("NED-DBpediaSpotlight");
+        componentList.add("QueryBuilderSimpleRealNameOfSuperHero");
+        URI priorConversation = new URI("urn:graph:806261d9-4601-4c8c-9999-926eee707c38");
+
+        qaProcess.setQuestion(question);
+        qaProcess.setcomponentlist(componentList);
+        qaProcess.setPriorConversation(priorConversation);
+        qaProcess.setLanguage("es"); // Spanish
+
+        String expected = "RequestQuestionAnsweringProcess " + // 
+                " -- question: \"What is the real name of Batman\"" + // 
+                " -- componentList: [NED-DBpediaSpotlight, QueryBuilderSimpleRealNameOfSuperHero]" + // 
+                " -- priorConversation: urn:graph:806261d9-4601-4c8c-9999-926eee707c38" + // 
+                " -- language: es";
 
         String actual = qaProcess.toString();
 


### PR DESCRIPTION
### QanaryQuestion
Fixed Errors in **QanaryQuestion** when:
1.  trying to retrieve a SPARQL Query, when none was in Triplestore -> **IndexOutOfBoundsException** in _getSparqlResult()_
2. trying to retrieve JSON Result ("answers" - JSONArray) when none was in Triplestore -> **NullPointerException** in _getJsonResult()_

### GerbilController
Changed **GerbilController** to return answers as specified by dice-group (see: [dice-group/gerbil/wiki/Question-Answering](https://github.com/dice-group/gerbil/wiki/Question-Answering#web-service-interface)) 

### Language
Changed how language is handled by the GerbilController and the Pipeline to accomodate for the parameter "lang" sent by gerbil, which contains the language of the question as ISO 639-1 code (see: [dice-group/gerbil/wiki/Question-Answering](https://github.com/dice-group/gerbil/wiki/Question-Answering#web-service-interface)). 
Until now language was expected to be in a _List\<String\>_, now language is a _String_.
The method _QanaryQuestion.getLanguage()_ could be used by Components in the future, to retrieve the language code. 