### PR TITLE
Integrate SSL connections into Qanary component archetype and template

### DIFF
--- a/qanary_component-archetype/src/main/resources/archetype-resources/src/main/resources/config/application.properties
+++ b/qanary_component-archetype/src/main/resources/archetype-resources/src/main/resources/config/application.properties
@@ -27,3 +27,13 @@ logging.level.org.springframework.jmx:WARN
 logging.level.org.springframework.mock:WARN
 logging.level.org.springframework.test:WARN
 logging.level.eu.wdaqua.qanary:DEBUG
+
+### SSL configuration
+# the path to the key store that contains the SSL certificate, e.g., classpath:keystore.p12
+server.ssl.key-store=
+# the password used to access the key store
+server.ssl.key-store-password=
+# the type of the key store (JKS or PKCS12)
+server.ssl.key-store-type=
+# toggle whether HTTP or HTTPS should be used (if SSL is set up)
+server.ssl.enabled=false

--- a/qanary_component-template/src/main/java/eu/wdaqua/qanary/component/QanaryComponentConfiguration.java
+++ b/qanary_component-template/src/main/java/eu/wdaqua/qanary/component/QanaryComponentConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import eu.wdaqua.qanary.commons.config.CacheConfig;
 import eu.wdaqua.qanary.commons.config.RestClientConfig;
@@ -24,6 +25,7 @@ public class QanaryComponentConfiguration {
 	private final Logger logger = LoggerFactory.getLogger(QanaryComponentConfiguration.class);
 	private Environment environment;
 	private final String[] propertiesToDisplayOnStartup = { //
+			"server.host", //
 			"server.port", //
 			"spring.application.name", //
 			"spring.application.description", //
@@ -91,7 +93,32 @@ public class QanaryComponentConfiguration {
 	}
 
 	public String getPropertyValue(String property) {
-		return this.environment.getProperty(property);
+		if (property.compareTo("server.host") == 0) {
+			return getHost();
+		} else {
+			return this.environment.getProperty(property);
+		}
+	}
+
+	public String getBaseUrl() {
+		try {
+			String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+				.toUriString();
+			return baseUrl;
+		} catch (Exception e) {
+			logger.warn("could not get base url: {}", e.getMessage());
+			return null;
+		}
+	}
+
+	// TODO: return the host on startup
+	// currently the context is only available after the application started
+	public String getHost() {
+		String baseUrl = this.getBaseUrl();
+		if (baseUrl != null) {
+			return baseUrl.substring(0, baseUrl.lastIndexOf(":"));
+		}
+		return null;
 	}
 
 	public String toString() {

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryEmbeddedQaWebFrontendController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryEmbeddedQaWebFrontendController.java
@@ -97,7 +97,7 @@ public class QanaryEmbeddedQaWebFrontendController {
 
 		// Send the question to the startquestionansweringwithtextquestion
 		ResponseEntity<?> response = qanaryQuestionAnsweringController.startquestionansweringwithtextquestion(question,
-				qanaryConfigurator.getDefaultComponentNames(), null, null, null, null, null);
+				qanaryConfigurator.getDefaultComponentNames(), null, null, null, null);
 		QanaryQuestionAnsweringRun run = (QanaryQuestionAnsweringRun) response.getBody();
 		logger.warn("response from startquestionansweringwithtextquestion: {}", run);
 

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfiguration.java
@@ -39,6 +39,7 @@ public class QanaryPipelineConfiguration {
 			"server.port", //
 			"server.ssl.enabled", //
 			"qanary.triplestore", //
+			"qanary.process.allow-insert-queries", //
 			"qanary.questions.directory", //
 			"qanary.components", //
 			"qanary.ontology"};
@@ -64,6 +65,8 @@ public class QanaryPipelineConfiguration {
 			}
 		}
 		logger.info("Current Configuration: \n{}", this);
+
+		this.printConfigurationWarnings();
 
 		// log all properties that are important (see
 		// debugPropertiesPrefixesToBeShowOnStartup) to DEBUG log
@@ -215,6 +218,10 @@ public class QanaryPipelineConfiguration {
 		}
 	}
 
+	public boolean getInsertQueriesAllowed() {
+		return Boolean.parseBoolean(this.environment.getProperty("qanary.process.allow-insert-queries"));
+	}
+
 
 	/**
 	 * default value is System.getProperty("user.dir") if configuration is not
@@ -255,5 +262,14 @@ public class QanaryPipelineConfiguration {
 					this.getProperty(commonPropertiesToBeShownOnStartup[i]));
 		}
 		return result;
+	}
+
+	/**
+	 * warn users of potentially unwanted configurations
+	 */
+	public void printConfigurationWarnings() {
+		if (this.getInsertQueriesAllowed()) {
+			logger.warn("enabling qanary.process.allow-insert-queries may pose a security risk");
+		}
 	}
 }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/StringToInsertQueryConverter.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/StringToInsertQueryConverter.java
@@ -1,0 +1,15 @@
+package eu.wdaqua.qanary.web;
+
+import eu.wdaqua.qanary.web.messages.AdditionalTriples;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToInsertQueryConverter implements Converter<String, AdditionalTriples> {
+
+	@Override
+	public AdditionalTriples convert(String triples) {
+		return new AdditionalTriples(triples);
+	}
+}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/AdditionalTriples.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/AdditionalTriples.java
@@ -1,0 +1,120 @@
+package eu.wdaqua.qanary.web.messages;
+
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.query.QueryParseException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+public class AdditionalTriples {
+	private String insertQuery;
+
+	private static final Logger logger = LoggerFactory.getLogger(AdditionalTriples.class);
+
+	public AdditionalTriples(String insertQuery) {
+		if (insertQuery != null) {
+			try {
+				this.insertQuery = parseInsertQuery(addBindsToInsertQuery(insertQuery));
+				logger.info("initializing AdditionalTriples with query \n{}", this.insertQuery);
+			} catch (Exception e) {
+				logger.warn("initializing no additional triples: \n{}", e.getMessage());
+				this.insertQuery = null;
+			}
+		} else {
+			logger.info("initializing no additional triples");
+			this.insertQuery = null;
+		}
+	}
+
+	public String getInsertQuery() {
+		return this.insertQuery;
+	}
+
+	@Deprecated
+	public String getInsertQueryForGraph(String graph) {
+		return this.insertQuery.replace("<GRAPH>", "<"+graph+">");
+	}
+
+	private String addBindsToInsertQuery(String insertQuery) {
+		String sparqlBinds = getSparqlBindsForVariables(insertQuery);
+		if (sparqlBinds.length()>0) {
+			return insertQuery+""// 
+				+ " WHERE { " //
+				+ sparqlBinds
+				+"} "; //
+		} else return insertQuery;
+	}
+
+	private String getSparqlBindsForVariables(String insertQuery) {
+		String sparqlBinds = "";
+
+		List<String> unnamed = findAdditionalVaraibles(insertQuery);
+
+		for (String i : unnamed) {
+			logger.info("adding URI bind for var {}", i);
+			sparqlBinds += "BIND (IRI(str(RAND())) AS "+i+") . ";
+		}
+		return sparqlBinds;
+	}
+
+
+	private String parseInsertQuery(String expectedQuery) {
+		logger.info("parsing query: \n{}", expectedQuery);
+		Pattern pattern = Pattern.compile(".*(delete|clear|load)+.*");
+		Matcher matcher = pattern.matcher(expectedQuery.toLowerCase());
+		if (expectedQuery.length() == 0) {
+			logger.info("no additional SPARQL INSERT query was supplied");
+			return null;
+		} else if (matcher.find()) {
+			throw new QueryParseException(
+					"additional SPARQL queries must not contain either of DELETE | CLEAR | LOAD",
+					0, matcher.start() // column is not computed
+					);
+		} else if (!expectedQuery.toLowerCase().contains("insert")) {
+			throw new QueryParseException(
+					"additional SPARQL queries are expected to contain an insert statement", 0, 0);
+		} else {
+			try {
+				UpdateFactory.create(expectedQuery);
+				logger.info("successfully parsed additional SPARQL INSERT query");
+				return expectedQuery;
+			} catch (Exception e) {
+				logger.info("parsing additional SPARQL query failed with exception: \n{}", e.getLocalizedMessage());
+				return null;
+			}
+		}
+	}
+
+	/**
+	 * return a list of all variables used in a group of SPARQL triples
+	 *
+	 * @param additionalTriples
+	 * @return variables
+	 */
+	private List<String> findAdditionalVaraibles(String additionalTriples) {
+		int lastIdx = 0;
+		String varString;
+		List<String> variables = new ArrayList<String>();
+
+		while (lastIdx != -1) {
+			lastIdx = additionalTriples.indexOf("?", lastIdx);
+			int end = additionalTriples.indexOf(" ", lastIdx);
+
+			if (lastIdx != -1) {
+				varString = additionalTriples.substring(lastIdx, end);
+				if (!variables.contains(varString)) {
+					logger.info("found new var {} at ({},{})", varString, lastIdx, end);
+					variables.add(varString);
+				}
+				lastIdx += varString.length();
+			}
+		}
+		return variables;
+	}
+
+}

--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -62,6 +62,11 @@ qanary.questions.directory=
 ### while using Stardog version 5 or higher, set the following parameter to true
 qanary.triplestore.stardog5=true
 
+### you might want to insert additional triples before starting the question answering process.
+### this setting enables execution of additional SPARQL INSERT queries in the helper front end.
+### leaving this setting enabled might pose a security risk!
+qanary.process.allow-insert-queries=true
+
 ### if the pipeline component is providing a component by itself or is a component of a larger system,
 ### then the spring.boot.admin.url needs to be defined
 # example: spring.boot.admin.url=http://localhost:8080

--- a/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
+++ b/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
@@ -4,17 +4,32 @@
                 </div>
 			</div>
 
-            <div th:fragment="additionalprefixinput">
-                Prefixes: 
-                <div>
-                    <textarea rows=5 cols=50 type="text" name="additionalprefixes" id="additionalprefixes"></textarea>
-                </div>
-            </div>
-
             <div th:fragment="additionaltripleinput">
-                Triples:
+                INSERT query:
                 <div>
-                    <textarea rows=5 cols=50 type="text" name="additionaltriples" id="additionaltriples"></textarea>
+                    <textarea rows=10 cols=60 type="text" name="additionaltriples" id="additionaltriples"></textarea>
+                </div>
+                <div>
+                    Exmaple: 
+                    <p>
+                    This example adds an AnnotationOfQuestionLanguage. 
+                    <urn:qanary:currentGraph> and <urn:qanary:currentQuestion> will automatically
+                    point to the correct URIs for this question answering process. 
+                    Variables (?a) will be replaced by a random IRI. 
+                    I you decide to not use any variables, opt for INSERT DATA instead of INSERT.
+                    </p>
+                    <textarea readonly rows=10 cols=60 type="text" id="additionaltriplesexample">
+PREFIX qa: <http://www.wdaqua.eu/qa#> 
+PREFIX oa: <http://www.w3.org/ns/openannotation/core/>
+INSERT { 
+    GRAPH <urn:qanary:currentGraph> {
+        ?a a qa:AnnotationOfQuestionLanguage . 
+        ?a oa:hasBody "en" .
+        ?a oa:hasTarget <urn:qanary:currentQuestion> ;
+        oa:annotatedAt ?time  
+ } 
+} 
+                    </textarea>
                 </div>
             </div>
 

--- a/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
+++ b/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
@@ -10,15 +10,14 @@
         <h1>Start a QA process with a new textual question</h1>
         <form id="startForm" action="/startquestionansweringwithtextquestion" method="POST">
 			<div th:replace="lib/reusableforms::textquestioninput"/>
-			<div>
+			<div th:if="${@environment.getProperty('qanary.process.allow-insert-queries') == 'true'}">
 				<button type="button" id="showadditionalinput" onclick="showAdditionalInput()">
 					Load additional Triples
 				</button>
 				<div id="additionalinput" style="display:none;">
 					<p>Insert additional Triples into the triplestore before processing the 
-					question. Unassigned variables (?s) will be bound to a random IRI.
+					question.
 					</p>
-					<div th:include="lib/reusableforms::additionalprefixinput"/>
 					<div th:include="lib/reusableforms::additionaltripleinput"/>
 				</div>
 			</div>


### PR DESCRIPTION
Add the required configuration parameters to `application.properties` in Qanary component archetype.

Add getHost() method to Qanary component template to retrieve the host from the current context path instead of the hard-coded configuration in application.properties. This is required s.t. a component can register itself at the Spring Boot Admin endpoint.

Add the option to load additional triples into the triplestore before starting the question answering process.