### PR TITLE
use /sparql to query triplestore with yasgui

### DIFF
--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
@@ -127,6 +127,16 @@ public class QanaryQuestionAnsweringController {
 	}
 
 	/**
+	 * expose the model with the Qanary sparql query endpoint
+	 */
+	@ModelAttribute("sparqlEndpointOfCurrentQanaryPipeline")
+	public String sparqlEndpointOfCurrentQanaryPipeline() {
+		String baseUrlString = this.getQuestionAnsweringHostUrlString();
+		String sparqlEndpoint = baseUrlString+"sparql";
+		return sparqlEndpoint;
+	}
+
+	/**
 	 * a simple HTML input form for starting a question answering process with a
 	 * QuestionURI
 	 */

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
@@ -132,7 +132,7 @@ public class QanaryQuestionAnsweringController {
 	@ModelAttribute("sparqlEndpointOfCurrentQanaryPipeline")
 	public String sparqlEndpointOfCurrentQanaryPipeline() {
 		String baseUrlString = this.getQuestionAnsweringHostUrlString();
-		String sparqlEndpoint = baseUrlString+"sparql";
+		String sparqlEndpoint = baseUrlString + QanarySparqlProtocolController.SPARQL_ENDPOINT;
 		return sparqlEndpoint;
 	}
 

--- a/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
+++ b/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
@@ -70,8 +70,8 @@
 		</div>
  		<div th:replace="lib/footer"/>
 		<!-- load React -->
-		<script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
-		<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
+		<script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin="anonymous"></script>
+		<script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin="anonymous"></script>
 </body>
 	<script th:inline="javascript">
 		// TODO: move to a JS file
@@ -363,7 +363,7 @@
 
 		// AJAX request to triplestore endpoint with created query
 		function queryStardog(stardogQuery, callback) {
-			// TODO: configurations might be specific to the Stardog triplestore -> need to be tested on different triplestores  
+			// TODO: configurations need to be tested on different triplestores 
 			console.log("querying triplestore ...");
 			let triplestoreQueryUrl = /*[[${triplestoreEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf";
 			let url = triplestoreQueryUrl + "?reasoning=false&query=" + encodeURIComponent(stardogQuery);
@@ -390,6 +390,7 @@
 			this.message = message;
 			this.name = "Unable to get query"
 		}
+		
 		GetQueryException.prototype.toString = function () {
 			return this.name + ': ' + this.message;
 		}

--- a/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
+++ b/qanary_pipeline-template/src/main/resources/templates/startquestionansweringwithtextquestion.html
@@ -169,7 +169,7 @@
 						return [
 							// list of endpoints to be suggested in the endpoint input field
 							{
-								endpoint: /*[[${triplestoreEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf"
+								endpoint: /*[[${sparqlEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf"
 							},
 							{   // default DBpedia SPARQL endpoint
 								endpoint: "https://dbpedia.org/sparql"
@@ -207,10 +207,9 @@
 						"}\n",
 				used:false,
 				requestConfig: {
-					endpoint: /*[[${triplestoreEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf",
+					endpoint: /*[[${sparqlEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf",
 					headers: () => ({
 						Accept:'application/sparql-results+json',
-						Authorization: 'Basic YWRtaW46YWRtaW4=' // Stardog specific
 					}),
 					method: 'GET'
 				},
@@ -233,10 +232,9 @@
 						"}\n",
 				used:false,
 				requestConfig: {
-					endpoint: /*[[${triplestoreEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf",
+					endpoint: /*[[${sparqlEndpointOfCurrentQanaryPipeline}]]*/ "QanaryPipelineSparqlEndpointToBeReplacedByThyMeLeaf",
 					headers: () => ({
 						Accept:'application/sparql-results+json',
-						Authorization: 'Basic YWRtaW46YWRtaW4=' // Stardog specific
 					}),
 					method: 'GET'
 				},
@@ -383,7 +381,6 @@
 				}],
 				headers:{
 					Accept:'application/sparql-results+json',
-					Authorization: 'Basic YWRtaW46YWRtaW4='
 				},
 			});
 		}


### PR DESCRIPTION
Don't query the triplestore directly from the Yasgui frontend
implementation. Use the endpoint provided by the pipeline instead.

Introduce new ModelAttribute to expose the required endpoint.
Remove Authorization header fields (they are no longer needed).