### PR TITLE
[fix] set question file encoding to UTF-8

### DIFF
--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionController.java
@@ -5,7 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.UUID;
@@ -113,7 +113,7 @@ public class QanaryQuestionController {
 
 		// Save the file locally
 		try (final BufferedOutputStream stream = new BufferedOutputStream(new FileOutputStream(new File(filepath)))){
-			stream.write(questionstring.getBytes(Charset.defaultCharset()));
+			stream.write(questionstring.getBytes(StandardCharsets.UTF_8));
 		}
 
 		final URI uriOfQuestion = new URI(this.getHost() + "/question/" + filename);


### PR DESCRIPTION
### Description of the problem
In the `QanaryQuestionController` questions are [written to a file using the system default character encoding](https://github.com/WDAqua/Qanary/blob/9a333985d3282d221a25aac9f9414274602621b9/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionController.java#L116) returned by [Charset.defaultCharset()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/charset/Charset.html#defaultCharset()). These charsets differ for each system, on Ubuntu 22.04 the default charset is `US-ASCII` while Windows 10 uses `windows-1252`:

Ubuntu 22.04:
```
jshell> import java.nio.charset.Charset;
jshell> Charset.defaultCharset();
$2 ==> US-ASCII
```

Windows 10:
```
jshell> import java.nio.charset.Charset;
jshell> Charset.defaultCharset();
$2 ==> windows-1252
```

In the unit test `testCreateTextQuestion` in `QanaryQuestionControllerTest`, the [file just written is read](https://github.com/WDAqua/Qanary/blob/9a333985d3282d221a25aac9f9414274602621b9/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryQuestionControllerTest.java#L57) with the function [Files.readString()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readString(java.nio.file.Path)) which defaults to `UTF-8`. This causes the unit test to fail for questions containing non-ASCII characters:
```
-------------------------------------------------------------------------------
Test set: eu.wdaqua.qanary.QanaryQuestionControllerTest
-------------------------------------------------------------------------------
Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.507 s <<< FAILURE! - in eu.wdaqua.qanary.QanaryQuestionControllerTest
testCreateTextQuestion  Time elapsed: 0.832 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: 'Wie viele L<C3><A4>nder gibt es?' != 'Wie viele L?nder gibt es?' ==> expected: <Wie viele L<C3><A4>nder gibt es?> but was: <Wie viele L?nder gibt es?>
        at eu.wdaqua.qanary.QanaryQuestionControllerTest.testCreateTextQuestion(QanaryQuestionControllerTest.java:60)
        at eu.wdaqua.qanary.QanaryQuestionControllerTest.testCreateTextQuestion(QanaryQuestionControllerTest.java:46)
```
`qanary_pipeline-template/target/surefire-reports/eu.wdaqua.qanary.QanaryQuestionControllerTest.txt`

### Steps to reproduce
```
git clone https://github.com/WDAqua/Qanary
cd Qanary
mvn clean test
```
The test will fail which also affects users that just want to build Qanary with `mvn clean install`.

### Fix
To fix this issue, the encoding must be set to UTF-8 when writing question files.