### PR TITLE
[fix] do not return arbitrary file names in QanaryAvailableQuestions API endpoint

### DIFF
--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryAvailableQuestions.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryAvailableQuestions.java
@@ -41,13 +41,13 @@ public class QanaryAvailableQuestions {
                 try {
                     availablequestions.add(new URL(host + "/question/" + fileEntry.getName() + "/"));
                 } catch (MalformedURLException e) {
-                    logger.warn("could not create URL from " + fileEntry + ": " + e.getMessage());
+                    logger.warn("could not create URL from {}: {}", fileEntry, e.getMessage());
                     throw e;
                 }
             }
         }
 
-        logger.info("found " + this.availablequestions.size() + " questions in " + folder.getAbsolutePath());
+        logger.info("found {} questions in {}", this.availablequestions.size(), folder.getAbsolutePath());
 
     }
 

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryAvailableQuestions.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryAvailableQuestions.java
@@ -26,6 +26,7 @@ public class QanaryAvailableQuestions {
     public QanaryAvailableQuestions(String directoryForStoringQuestionRawData, String host) throws IOException {
     	if( directoryForStoringQuestionRawData.isBlank() ) {
     		directoryForStoringQuestionRawData = "."; // fallback if no custom configuration was defined
+            logger.warn("No directory for storing question raw data was configured. Files will be stored on the current execution path which may not be a suitable location!");
     	}
     	
         File folder = new File(directoryForStoringQuestionRawData);
@@ -36,9 +37,7 @@ public class QanaryAvailableQuestions {
         }
 
         for (final File fileEntry : folder.listFiles()) {
-            if (fileEntry.isDirectory()) {
-                // skip
-            } else {
+            if (fileEntry.isFile() && fileEntry.getName().startsWith("stored-question")) { // only return stored-question files created by qanary
                 try {
                     availablequestions.add(new URL(host + "/question/" + fileEntry.getName() + "/"));
                 } catch (MalformedURLException e) {
@@ -48,7 +47,7 @@ public class QanaryAvailableQuestions {
             }
         }
 
-        logger.info("found: " + this.availablequestions.size() + " in " + directoryForStoringQuestionRawData);
+        logger.info("found " + this.availablequestions.size() + " questions in " + folder.getAbsolutePath());
 
     }
 


### PR DESCRIPTION
## Description of the problem
When no directory for string raw question data is configured in the `application.properties` a fallback is implemented to store these files on the current execution path. Also there are no checks what files will be included.

In the default configuration the following will be returned when executing the qanary pipeline from `/opt/Qanary` and quering the `/question` api endpoint:

```sh
qanary@qanary:/opt/Qanary$ java -jar qanary_pipeline-template/target/qa.pipeline-3.1.0.jar
qanary@qanary:/opt/Qanary$ curl http://localhost:8080/question/
```

```json
{
  "availableQuestions": [
    "http://localhost:8080/question/pom.xml/",
    "http://localhost:8080/question/README.md/",
    "http://localhost:8080/question/.gitignore/",
    "http://localhost:8080/question/.env/",
    "http://localhost:8080/question/stored-question__text_be4ec9ea-f4c8-4d49-bd81-b4ca45845956/",
    "http://localhost:8080/question/docker-compose.yml/"
  ]
}
```

This returns all files that are stored at the execution path `/opt/Qanary`:
```sh
qanary@qanary:/opt/Qanary$ ls -lh
total 64K
drwxrwxr-x 3 qanary qanary 4.0K Apr 30 18:37 ICWE-results
-rw-rw-r-- 1 qanary qanary 8.3K Apr 30 18:37 README.md
drwxrwxr-x 2 qanary qanary 4.0K Apr 30 19:16 additional-triples
drwxrwxr-x 2 qanary qanary 4.0K Apr 30 18:37 doc
-rw-rw-r-- 1 qanary qanary  510 Apr 30 18:37 docker-compose.yml
-rw-rw-r-- 1 qanary qanary  688 Apr 30 18:37 pom.xml
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 19:46 qald-evaluator
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 18:37 qanary-configuration-frontend
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 19:46 qanary_commons
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 19:46 qanary_component-archetype
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 19:46 qanary_component-template
drwxrwxr-x 2 qanary qanary 4.0K Apr 30 18:37 qanary_pipeline-client
drwxrwxr-x 4 qanary qanary 4.0K Apr 30 19:46 qanary_pipeline-template
-rw-rw-r-- 1 qanary qanary   27 Apr 30 19:16 stored-question__text_be4ec9ea-f4c8-4d49-bd81-b4ca45845956
```

## Fix
I've added a check to include only files with names beginning with `stored-question`. Also I've added a warning log message if the fallback to the execution path occurs.