### PR TITLE
Update Configuration Access

### DIFF
--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>qa.pipeline</artifactId>
 	<groupId>eu.wdaqua.qanary</groupId>
-	<version>3.3.4</version>
+	<version>3.4.0</version>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/ApplicationWebSecurityConfigurerAdapter.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/ApplicationWebSecurityConfigurerAdapter.java
@@ -18,6 +18,14 @@ public class ApplicationWebSecurityConfigurerAdapter extends WebSecurityConfigur
 	private String access;
 	private String username;
 	private String password;
+	private String[] publicUrls = new String[] {
+		"/*question*",
+		"/qa",
+		"/gerbil",
+		"/login",
+		"/instances",
+		"/sparql"
+	};
 
 	public ApplicationWebSecurityConfigurerAdapter(@Autowired Environment env) {
 		this.setAccessConfiguration(env);
@@ -34,7 +42,7 @@ public class ApplicationWebSecurityConfigurerAdapter extends WebSecurityConfigur
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
-		http.csrf().disable();
+		http.csrf().ignoringAntMatchers(publicUrls);
 
         switch(access) {
             case QanaryConfigurationAccessParameters.DISALLOWACCESS:

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/ApplicationWebSecurityConfigurerAdapter.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/ApplicationWebSecurityConfigurerAdapter.java
@@ -4,6 +4,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
 /**
  * configure Spring Security: CSRF protection is disabled
  */
@@ -13,5 +19,47 @@ public class ApplicationWebSecurityConfigurerAdapter extends WebSecurityConfigur
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.csrf().disable();
+
+		// TODO: use application.properties
+        String configurationAccess = "web";
+
+        switch(configurationAccess) {
+            case "disallow":
+	    		http
+	    			.authorizeRequests()
+	    				.antMatchers("/").denyAll()
+	    				.anyRequest().permitAll();
+				break;
+            case "web":
+	    		http
+	    			.authorizeRequests()
+	    				.antMatchers("/").authenticated() 
+	    				.anyRequest().permitAll()
+	    				.and() 
+	    			.formLogin()
+	    				.loginPage("/login")
+	    				.permitAll()
+	    				.and()
+	    			.logout()
+	    				.permitAll();
+				break;
+            default:
+                throw new Exception("undefined access type");
+        }
+	}
+
+	@Bean
+	@Override
+	public UserDetailsService userDetailsService() {
+		UserDetails user =
+			// TODO: use correct encoder for production
+			// TODO: use credentials from config
+			 User.withDefaultPasswordEncoder()
+				.username("admin")
+				.password("admin")
+				.roles("USER")
+				.build();
+
+		return new InMemoryUserDetailsManager(user);
 	}
 }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryConfigurationAccessParameters.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryConfigurationAccessParameters.java
@@ -1,0 +1,17 @@
+package eu.wdaqua.qanary.web;
+
+/**
+ * provides a standard definition of common configuration paramters
+ */
+public interface QanaryConfigurationAccessParameters {
+	final String ACCESSKEY = "configuration.access";
+	final String USERNAMEKEY = "configuration.username";
+	final String PASSWORDKEY = "configuration.password";
+	final String DEFAULTUSERNAME = "admin";
+	final String DEFAULTPASSWORD = "admin";
+	final String DEFAULTACCESSTYPE = "disallow";
+	final String WEBACCESS = "web";
+	final String DISALLOWACCESS = "disallow";
+	final String LOGINENDPOINT = "/login";
+	final String CONFIGURATIONENDPOINT = "/configuration";
+}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
@@ -54,6 +54,7 @@ public class QanaryPipelineConfigurationController {
 
     /**
      * returns configurable properties and their values based on the Environment
+     * @throws Exception
      */
     @RequestMapping(value = "/configuration", method = RequestMethod.GET, produces = "application/json")
     public ResponseEntity<JSONObject> getConfigurablePipelineProperties() {

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
@@ -6,7 +6,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.json.JSONObject;
 import org.json.JSONException;
@@ -48,7 +52,6 @@ public class QanaryPipelineConfigurationController {
         for (String property : excludedProperties) {
             propertyMap.remove(property);
         }
-
         return propertyMap;
     }
 
@@ -57,24 +60,28 @@ public class QanaryPipelineConfigurationController {
      * @throws Exception
      */
     @RequestMapping(value = "/configuration", method = RequestMethod.GET, produces = "application/json")
-    public ResponseEntity<JSONObject> getConfigurablePipelineProperties() {
+    public ResponseEntity<String> getConfigurablePipelineProperties() {
 
         Map<String, Object> configurationMap = qanaryPipelineConfiguration.getAllKnownProperties(this.environment);
-
         this.excludeProperties(this.notConfigurable, configurationMap);
 
-        JSONObject json = new JSONObject(configurationMap);
-        ResponseEntity<JSONObject> response = new ResponseEntity<>(json, HttpStatus.OK);
-
-        return response;
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            String jsonString = objectMapper.writeValueAsString(configurationMap);
+            return new ResponseEntity<>(jsonString, HttpStatus.OK);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     /**
      * writes changes in pipeline property values to application.local.properties
      */
     @RequestMapping(value = "/configuration", method = RequestMethod.POST, consumes = "application/json")
-    public void updateLocalPipelineProperties(@RequestBody JSONObject configJson) throws JSONException {
+    public void updateLocalPipelineProperties(@RequestBody String jsonString) throws JSONException {
 
+        JSONObject configJson = new JSONObject(jsonString);
         String filePath = environment.getProperty("spring.config.location");
         Path localConfigPath = Paths.get(new ClassPathResource(filePath).getPath());
 
@@ -98,11 +105,15 @@ public class QanaryPipelineConfigurationController {
 
         try {
             FileWriter writer = new FileWriter(filePath);
+            Iterator<String> keys = configJson.keys();
+            logger.info("writing keys ...");
+            while(keys.hasNext()) {
+                String key = keys.next();
+                String value = configJson.get(key).toString();
 
-            for( Object key : (Iterable)configJson.keys()) {
-                String value = configJson.get(key.toString()).toString();
                 writer.write(key+"="+value+"\n");
             }
+
             logger.info("saved configuration to application.local.properties");
             writer.close();
 

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
@@ -38,7 +38,9 @@ public class QanaryPipelineConfigurationController {
     private final Environment environment;
     private final QanaryPipelineConfiguration qanaryPipelineConfiguration;
     // define properties that should not be configurable using this controller
-    private final String[] notConfigurable = {"server.host", "server.port", "qanary.components", "spring.config.name"};
+    private final String[] notConfigurable = {
+        "server.host", "server.port", "qanary.components", "spring.config.name",
+        "configuration.username", "configuration.password"};
 
     @Autowired
     public QanaryPipelineConfigurationController(
@@ -59,8 +61,10 @@ public class QanaryPipelineConfigurationController {
      * returns configurable properties and their values based on the Environment
      * @throws Exception
      */
-    @RequestMapping(value = "/configuration", method = RequestMethod.GET, produces = "application/json")
-    public ResponseEntity<String> getConfigurablePipelineProperties() {
+    @RequestMapping(
+        value = QanaryConfigurationAccessParameters.CONFIGURATIONENDPOINT, 
+        method = RequestMethod.GET, produces = "application/json")
+        public ResponseEntity<String> getConfigurablePipelineProperties() {
 
         Map<String, Object> configurationMap = qanaryPipelineConfiguration.getAllKnownProperties(this.environment);
         this.excludeProperties(this.notConfigurable, configurationMap);
@@ -78,7 +82,9 @@ public class QanaryPipelineConfigurationController {
     /**
      * writes changes in pipeline property values to application.local.properties
      */
-    @RequestMapping(value = "/configuration", method = RequestMethod.POST, consumes = "application/json")
+    @RequestMapping(
+        value = QanaryConfigurationAccessParameters.CONFIGURATIONENDPOINT, 
+        method = RequestMethod.POST, consumes = "application/json")
     public void updateLocalPipelineProperties(@RequestBody String jsonString) throws JSONException {
 
         JSONObject configJson = new JSONObject(jsonString);

--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -90,6 +90,11 @@ qanary.components=
 ### define what additional (local) properties files should be used
 spring.config.location=application.local.properties
 
+### define security access paramters 
+qanary.config.access=disallow
+qanary.config.username=
+qanary.config.password=
+
 ### Springdoc configuration
 springdoc.version=1.6.0
 # swagger-ui custom path

--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -91,9 +91,9 @@ qanary.components=
 spring.config.location=application.local.properties
 
 ### define security access paramters 
-qanary.config.access=disallow
-qanary.config.username=
-qanary.config.password=
+configuration.access=web
+configuration.username=
+configuration.password=
 
 ### Springdoc configuration
 springdoc.version=1.6.0

--- a/qanary_pipeline-template/src/main/resources/templates/hello.html
+++ b/qanary_pipeline-template/src/main/resources/templates/hello.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+    <head>
+        <title>Hello World!</title>
+    </head>
+    <body>
+        <h1 th:inline="text">Hello [[${#httpServletRequest.remoteUser}]]!</h1>
+        <form th:action="@{/logout}" method="post">
+            <input type="submit" value="Sign Out"/>
+        </form>
+    </body>
+</html>

--- a/qanary_pipeline-template/src/main/resources/templates/login.html
+++ b/qanary_pipeline-template/src/main/resources/templates/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+    <head>
+        <title>Spring Security Example </title>
+    </head>
+    <body>
+        <div th:if="${param.error}">
+            Invalid username and password.
+        </div>
+        <div th:if="${param.logout}">
+            You have been logged out.
+        </div>
+        <form th:action="@{/login}" method="post">
+            <div><label> User Name : <input type="text" name="username"/> </label></div>
+            <div><label> Password: <input type="password" name="password"/> </label></div>
+            <div><input type="submit" value="Sign In"/></div>
+        </form>
+    </body>
+</html>


### PR DESCRIPTION
Implement configuration access security flag for Qanary v3.

Add flag `configuration.access' to application.properties with allowed values:
* `disallow`: web access is disabled for specific pages
* `web`: web access to specific pages is enabled only with credentials 

Add corresponding credentials as `configuration.username` and `configuration.password`. Use default values if they are not set. 

---

Refactor the `/configuration` endpoint. 
* `GET`: return current configuration from environment (Json)
* `POST`: allow modification of certain parameters by passing a custom configuration (Json)

By default, access to this endpoint is restricted (see above).