### PR TITLE
Update select_all_AnnotationOfAnswerSPARQL.rq

### DIFF
--- a/qanary_commons/src/main/resources/queries/select_all_AnnotationOfAnswerSPARQL.rq
+++ b/qanary_commons/src/main/resources/queries/select_all_AnnotationOfAnswerSPARQL.rq
@@ -11,7 +11,7 @@ WHERE {
         ?annotationId oa:hasTarget ?hasTarget ;
         oa:hasBody ?hasBody .
         OPTIONAL {
-        ?annotationnId qa:score ?score ;
+        ?annotationId qa:score ?score .
         }
         ?annotationId oa:annotatedAt ?annotatedAt ;
         oa:annotatedBy ?annotatedBy . 


### PR DESCRIPTION
Fixed typo `?annotationnId qa:score ...` -> `?annotationId qa:score ...`

This typo led to unwanted results when querying for Annotation(s)OfAnswerSPARQL when executed with several different components which provide a score.