### PR TITLE
Fix registration for questionanswering frontend

### DIFF
--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>qa.pipeline</artifactId>
     <groupId>eu.wdaqua.qanary</groupId>
-    <version>3.9.2</version>
+    <version>3.9.3</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifier.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifier.java
@@ -46,10 +46,8 @@ public class QanaryComponentRegistrationChangeNotifier extends AbstractEventNoti
 						logger.warn("registering component \"{}\" has no callable URL ({})", instanceName,
 								instance.getRegistration().getServiceUrl());
 					}
-				} else if(status.toUpperCase().compareTo("OFFLINE") == 0) {
-					availableComponents.remove(instanceName);
 				} else {
-					availableComponents.put(instanceName, null);
+					availableComponents.put(instanceName, instance);
 				}
 			} else {
 				logger.debug("Instance {} ({}) {}", instanceName, event.getInstance(), event.getType());
@@ -65,12 +63,11 @@ public class QanaryComponentRegistrationChangeNotifier extends AbstractEventNoti
 		return new ArrayList<>(availableComponents.keySet());
 	}
 
-	@Cacheable
-	public Map<String, String> getComponentsAndAvailability() {
-		return this.availableComponents.entrySet().stream().collect(Collectors.toMap(
-				Map.Entry::getKey,
-				entry -> entry.getValue().getStatusInfo().getStatus()
-		));
+	@Cacheable(value = "availableComponents") // TODO: Handle changes ?
+	public Map<String, String> getComponentsAndAvailability(Map<String, Instance> availableComponents) {
+		Map<String,String> comps = availableComponents.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e->e.getValue().getStatusInfo().getStatus()));
+		logger.info("Comps: {}", comps);
+		return comps;
 	}
 
 	public Map<String, Instance> getAvailableComponents() {

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionAnsweringController.java
@@ -129,9 +129,9 @@ public class QanaryQuestionAnsweringController {
 	 * expose the model with the component names
 	 */
 	@ModelAttribute("componentList")
-	public List<String> componentList() {
-		logger.info("available components: {}", myComponentNotifier.getAvailableComponentNames());
-		return myComponentNotifier.getAvailableComponentNames();
+	public Map<String,String> componentList() {
+			logger.info("available components: {}", myComponentNotifier.getAvailableComponentNames());
+		return myComponentNotifier.getComponentsAndAvailability(myComponentNotifier.getAvailableComponents());
 	}
 
 	/**

--- a/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
+++ b/qanary_pipeline-template/src/main/resources/templates/lib/reusableforms.html
@@ -58,10 +58,10 @@ _:a oa:hasTarget <urn:qanary:currentQuestion> .
                     	<div id="componentfilterbox"><input title="filter components" type="text" id="componentfilterinput" onkeyup="filterComponentList()" name="componentfilterinput" placeholder="filter components"></div>
                 	</div>
                     <ul id="sortable">
-                        <li th:each="component : ${componentList}">
-                        	<input type="checkbox" name="componentlist[]" th:id="'componentlist'+${component}" th:value="${component}" />
-                            <label th:for="'componentlist'+${component}" th:title="'activate '+${component}+' for the QA pipeline'" th:text="${component}" />
-                            <span th:id="'annotationcount'+${component}"></span>
+                        <li th:each="component : ${componentList}" th:style="'background-color: ' + (${component.value == 'OFFLINE'} ? '#999' : '')">
+                        	<input type="checkbox" name="componentlist[]" th:id="'componentlist'+${component.key}" th:value="${component.key}" th:attrappend="disabled=${component.value == 'OFFLINE' ? 'disabled' : null}"/>
+                            <label th:for="'componentlist'+${component.key}" th:title="'activate '+${component.key}+' for the QA pipeline'" th:text="${component.key}" />
+                            <span th:id="'annotationcount'+${component.key}"></span>
                         </li>
                     </ul>
 				</div>


### PR DESCRIPTION
> Implement a method to indicate whether a component is accessible or not

Fixed by:

- Passing the Map<Component name, status> to the Thymeleaf template instead of List
- Each request to /startquestionansweringwithtextquestion calls the cached method that returns that map
- Offline components can't be selected and appear in a darker gre