### PR TITLE
Upgrade springdoc version to 1.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ hs_err_pid*
 
 ### locally stored files
 stored-question*
+**/additional-triples/
 
 
 **/error

--- a/qanary_component-parent/pom.xml
+++ b/qanary_component-parent/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary</groupId>
     <artifactId>qa.qanarycomponent-parent</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>pom</packaging>
 	<parent>
 		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent -->
@@ -18,9 +18,9 @@
 		<java.version>17</java.version>
 		<spring-boot-admin.version>2.7.12</spring-boot-admin.version>
 		<qanary.component.version>[3.9.2,4.0.0)</qanary.component.version>
-		<qanary.commons.version>[3.11.0,4.0.0)</qanary.commons.version>
+		<qanary.commons.version>[3.16.0,4.0.0)</qanary.commons.version>
 		<junit-jupiter.version>5.8.2</junit-jupiter.version>
-		<springdoc.version>1.7.0</springdoc.version>
+		<springdoc.version>1.8.0</springdoc.version>
 		<json-path.version>2.9.0</json-path.version>
 	</properties>
 

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>qa.pipeline</artifactId>
     <groupId>eu.wdaqua.qanary</groupId>
-    <version>3.10.1</version>
+    <version>3.10.2</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -14,7 +14,8 @@
     <properties>
         <java.version>11</java.version>
         <spring-boot-admin.version>2.7.16</spring-boot-admin.version>
-        <qanary.version>[3.16.0,4.0.0)</qanary.version>
+        <qanary.component.version>[3.11.1,4.0.0)</qanary.component.version>
+        <qanary.commons.version>[3.16.0,4.0.0)</qanary.commons.version>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
         <docker.image.prefix>qanary</docker.image.prefix>
         <docker.image.name>qanary-pipeline</docker.image.name>
@@ -28,7 +29,13 @@
         <dependency>
             <groupId>eu.wdaqua.qanary</groupId>
             <artifactId>qa.commons</artifactId>
-            <version>${qanary.version}</version>
+            <version>${qanary.commons.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.wdaqua.qanary</groupId>
+            <artifactId>qa.component</artifactId>
+            <version>${qanary.component.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.codecentric</groupId>
@@ -233,12 +240,6 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>eu.wdaqua.qanary</groupId>
-            <artifactId>qa.component</artifactId>
-            <version>3.11.1</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Upgrade the version for common springdoc dependencies in the component-parent POM from 1.7.0 to 1.8.0.

Addition: 
Add a version ranger for `qa.component` to the pipeline-template POM. 

This is still marked as a draft, because making the same upgrade in the pipeline-template caused an Error during testing (see #287 ).

