### PR TITLE
Significantly improve framework testing quality (#388)

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,49 @@
+name: Dependency vulnerability scan (OWASP)
+
+# Software Composition Analysis: scans the project's dependencies against the
+# National Vulnerability Database. Kept off the per-PR path because the NVD data
+# download is slow; runs weekly and on demand. Report-only (does not fail the
+# build) -- review the uploaded report.
+#
+# Requires an NVD API key (free: https://nvd.nist.gov/developers/request-an-api-key)
+# stored as the repository secret NVD_API_KEY, otherwise the NVD download is
+# heavily throttled.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1' # Mondays 04:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build & install artifacts (resolve internal versions)
+        run: mvn clean install -Dgpg.skip -DskipTests -Ddockerfile.skip
+
+      - name: OWASP dependency-check (aggregate, report-only)
+        # failBuildOnCVSS defaults to 11 (never fails); this only produces a report.
+        run: >
+          mvn org.owasp:dependency-check-maven:10.0.4:aggregate
+          -DnvdApiKey=${{ secrets.NVD_API_KEY }}
+          -Dformats=HTML,JSON
+          -Dgpg.skip
+
+      - name: Upload dependency-check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: '**/target/dependency-check-report.*'
+          if-no-files-found: warn

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,47 @@
+name: Integration tests (Testcontainers)
+
+# Docker-dependent integration tests (Testcontainers spins up the project's real
+# Virtuoso image). Kept separate from the fast per-PR unit tests: the *IT classes
+# are not picked up by the normal `mvn test`, so they only run here.
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest # provides a Docker daemon for Testcontainers
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build & install artifacts (resolve internal versions)
+        run: mvn clean install -Dgpg.skip -DskipTests -Ddockerfile.skip
+
+      - name: Run all tests incl. Testcontainers (aggregate coverage)
+        # Runs the unit + Spring + Testcontainers (*IT) tests together so the
+        # JaCoCo report reflects ALL tests (e.g. the live-Virtuoso connector,
+        # which is 0% in the unit-only PR run). Docker is available on the runner.
+        run: >
+          mvn clean test
+          -Dtest='*Test,*IT' -Dsurefire.failIfNoSpecifiedTests=false -Dgpg.skip
+
+      - name: Aggregate coverage summary (unit + integration)
+        if: always()
+        run: python3 service_config/jacoco-coverage-summary.py
+        env:
+          COVERAGE_THRESHOLD: '80'
+
+      - name: Upload aggregate coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-reports-aggregate
+          path: '**/target/site/jacoco/'
+          if-no-files-found: warn

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,39 @@
+name: Mutation testing (PIT)
+
+# Mutation testing is slow, so it is not part of the per-PR checks. Run it on
+# demand (Actions -> Run workflow) or on a weekly schedule. It verifies that the
+# tests actually detect injected faults, not merely execute the lines.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1' # Mondays 03:00 UTC
+
+jobs:
+  pit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build & install artifacts (resolve internal versions)
+        run: mvn clean install -Dgpg.skip -DskipTests -Ddockerfile.skip
+
+      - name: Run PIT mutation coverage (qanary_commons)
+        # jacoco.skip avoids the coverage agent in PIT's forked minion JVMs.
+        run: >
+          mvn -pl qanary_commons org.pitest:pitest-maven:mutationCoverage
+          -Djacoco.skip=true -Dgpg.skip
+
+      - name: Upload PIT reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pit-reports
+          path: '**/target/pit-reports/'
+          if-no-files-found: warn

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -21,6 +21,72 @@ jobs:
       - name: Build artifacts # To resolve internal, not yet published new versions
         run: mvn clean install -Dgpg.skip -DskipTests -Ddockerfile.skip
 
-      - name: Execute tests
+      - name: Execute tests with coverage
+        # 'mvn test' runs the JaCoCo agent (prepare-agent), writes the coverage
+        # report (jacoco:report -> target/site/jacoco) and evaluates the per-class
+        # 80% line-coverage gate (jacoco:check). The gate is report-only by default;
+        # set -Djacoco.haltOnFailure=true to make it fail the build.
         run: mvn test
 
+      - name: Test coverage summary + regression gate
+        if: always() # also summarise coverage when tests/gate fail
+        # Prints the per-module/overall summary and the list of classes below the
+        # advisory 80% per-class threshold (report-only). FAILS the job if overall
+        # or any module line coverage drops below the enforced floors below — a
+        # ratchet so coverage cannot silently regress. Raise the floors as coverage
+        # improves.
+        run: python3 service_config/jacoco-coverage-summary.py
+        env:
+          COVERAGE_THRESHOLD: '80'
+          COVERAGE_ENFORCE: 'false' # advisory per-class rule stays report-only
+          COVERAGE_MIN_OVERALL: '55'
+          COVERAGE_MIN_MODULE: 'qanary_commons=55,qanary_pipeline-template=48,qanary_component-template=65,qald-evaluator=90'
+
+      - name: Upload JaCoCo coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-coverage-reports
+          path: '**/target/site/jacoco/'
+          if-no-files-found: warn
+
+      - name: JaCoCo PR coverage comment (diff)
+        if: always()
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: ${{ github.workspace }}/**/target/site/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: JaCoCo coverage report
+          update-comment: true
+          min-coverage-overall: 55
+          min-coverage-changed-files: 0 # comment-only on changed files; the script is the gate
+
+      - name: Static analysis report (SpotBugs + FindSecBugs, report-only)
+        if: always()
+        # Full report for gradual triage (reuses the compiled classes). SpotBugs
+        # reads bytecode, so AspectJ weaving doesn't affect it. Full plugin
+        # coordinates because the 'spotbugs' prefix isn't in Maven's default groups.
+        run: mvn com.github.spotbugs:spotbugs-maven-plugin:spotbugs
+
+      - name: Upload SpotBugs reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spotbugs-reports
+          path: '**/target/spotbugsXml.xml'
+          if-no-files-found: warn
+
+      - name: Static analysis gate (high-severity patterns)
+        # Fails the build only on the curated high-severity correctness/security
+        # patterns in service_config/spotbugs-enforced.xml (all currently zero).
+        run: >
+          mvn com.github.spotbugs:spotbugs-maven-plugin:check
+          -Dspotbugs.includeFilterFile=$GITHUB_WORKSPACE/service_config/spotbugs-enforced.xml
+          -Dspotbugs.failOnError=true
+
+      - name: Formatting drift report (Spotless, non-blocking)
+        if: always()
+        continue-on-error: true # report-only until the team adopts `mvn spotless:apply`
+        run: >
+          mvn -pl qanary_commons,qanary_pipeline-template,qanary_component-template,qald-evaluator
+          com.diffplug.spotless:spotless-maven-plugin:check

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret scan (gitleaks)
+
+# Scans the working tree and the full git history for leaked secrets
+# (credentials, API keys, etc.). Helps prevent a recurrence of the historically
+# committed Virtuoso credential (see SECURITY.md, task 1.6).
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # full history so the scan covers past commits too
+
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,10 @@ stored-question*
 
 **/.factorypath
 
+
+# test-generated additional-triples (redirected to target/ in tests)
+qanary_pipeline-template/additional-triples/
+additional-triples/
+
+# AspectJ weaver crash dumps
+ajcore.*.txt

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,72 @@
+# Building Qanary
+
+## Prerequisites
+
+- **JDK 21+** (the modules compile to Java 21; the build *enforces* this via
+  `maven-enforcer-plugin` and fails early on older JDKs).
+- **Maven 3.6.3+**.
+- Docker (only for the Testcontainers integration tests and the end-to-end example).
+
+## Common commands
+
+```bash
+mvn clean install              # full reactor build + unit/Spring tests + install
+mvn clean test                 # build + run the unit and Spring-context tests
+mvn clean install -Dmaven.test.skip=true   # build the artifacts (jars) without tests
+```
+
+Quality tooling (see also the workflows under `.github/workflows/`):
+
+```bash
+# Coverage (JaCoCo) – report + per-class 80% advisory gate run with `mvn test`;
+# print a summary / regression gate:
+python3 service_config/jacoco-coverage-summary.py
+
+# Static analysis (SpotBugs + FindSecBugs) – report, then the high-severity gate:
+mvn com.github.spotbugs:spotbugs-maven-plugin:spotbugs
+mvn com.github.spotbugs:spotbugs-maven-plugin:check \
+    -Dspotbugs.includeFilterFile=service_config/spotbugs-enforced.xml -Dspotbugs.failOnError=true
+
+# Formatting drift (Spotless, lightweight rules); adopt with :apply
+mvn -pl qanary_commons,qanary_pipeline-template,qanary_component-template,qald-evaluator \
+    com.diffplug.spotless:spotless-maven-plugin:check
+
+# Mutation testing (PIT) on the core module (slow):
+mvn -pl qanary_commons org.pitest:pitest-maven:mutationCoverage -Djacoco.skip=true
+
+# Testcontainers integration tests (*IT) – require Docker:
+mvn -pl qanary_commons test -Dtest='*IT' -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+## Known build gotcha: AspectJ "key not found in wovenClassFile"
+
+The pipeline and component modules weave the `qa.commons` dependency into their own
+classes at compile time (`aspectj-maven-plugin` `weaveDependencies`, for the
+explainability aspect). Because `qa.commons` is itself already woven by its own
+build, the consumers *re-weave* already-woven classes. The AspectJ weaver
+(`1.14.1` / `aspectjtools 1.9.25`) has an **intermittent** bug here that aborts the
+build with:
+
+```
+abort ABORT -- (RuntimeException) key not found in wovenClassFile
+```
+
+It is non-deterministic and shows up mainly during `aspectj:test-compile` of
+`qa.pipeline`, usually after interleaving partial/in-place builds. It is a
+**build-tooling flake, not a code error** — the same sources build cleanly on a
+clean pass.
+
+**Reliable recipes:**
+
+| Situation | Command |
+| --- | --- |
+| Normal build | `mvn clean install` (full reactor — most reliable) |
+| Build the runnable jar only (skips the test-compile weave entirely) | `mvn clean install -Dmaven.test.skip=true` |
+| Flake persists across clean builds | `mvn clean && rm -rf ~/.m2/repository/eu/wdaqua/qanary && mvn clean install` |
+
+**Avoid** repeated in-place `mvn -pl <module> test` runs without `clean`; they tend
+to corrupt the incremental weave state. Prefer a full-reactor `mvn clean test`, and
+in CI always start from a clean checkout (which is unaffected).
+
+A proper fix (tracked as a follow-up) is to evaluate a newer AspectJ
+weaver/plugin or load-time weaving so the dependency is not re-woven at build time.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security
+
+## Reporting a vulnerability
+
+Please report security issues privately to the maintainers
+(andreas.both@htwk-leipzig.de) rather than via public issues.
+
+## Secrets handling
+
+- **No real secrets are committed.** The pipeline's Virtuoso credential is supplied
+  at deploy/CI time: `service_config/files/pipeline` contains the placeholder
+  `VIRTUOSO_PASSWORD=SECRETS_VIRTUOSO_PASSWORD`, which `service_config/build_images.sh`
+  substitutes from the `$VIRTUOSO_PASSWORD` CI secret (task 1.6 verified the secret
+  never reaches a Docker image layer; the deploy injects it as a runtime env var).
+- `application.properties` ships only commented-out, non-secret placeholders
+  (e.g. `#virtuoso.password=dba`).
+- Automated **secret scanning** runs in CI (`.github/workflows/secret-scan.yml`,
+  gitleaks) over the working tree and full history.
+
+## Rotating the Virtuoso read/write credential
+
+The project's improvement backlog (task 1.6) flagged that a Virtuoso read/write
+password may have been committed historically. Treat any credential that was ever
+committed as compromised and rotate it. **These steps require infrastructure access
+and history rewriting and must be performed by a maintainer — they are intentionally
+not automated here.**
+
+1. **Rotate at the source.** On the Virtuoso server, change the `readWrite` user's
+   password (e.g. `set_user_password('readWrite', '<new>')` via isql, or the
+   Management UI → System Admin → User Accounts).
+2. **Update the secret store.** Set the new value in the CI/CD secret
+   `VIRTUOSO_PASSWORD` (GitHub Actions repo secret) and any deploy secret store. Do
+   **not** put it in a tracked file — the `SECRETS_VIRTUOSO_PASSWORD` placeholder
+   stays in git.
+3. **Confirm propagation.** Re-deploy; verify the pipeline connects with the new
+   credential and the old one is rejected.
+4. **Scrub history (optional, coordinated).** If a real secret is found in history,
+   rewrite it out with [git-filter-repo](https://github.com/newren/git-filter-repo)
+   or the [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/), e.g.:
+   ```bash
+   # back up the repo first; this rewrites history and requires a coordinated
+   # force-push + everyone re-cloning
+   git filter-repo --replace-text <(echo 'LITERAL_OLD_SECRET==>SECRETS_VIRTUOSO_PASSWORD')
+   ```
+   Rotation (step 1) is the real fix; scrubbing only removes the now-dead value.
+
+## Verifying the repository for leaked secrets
+
+```bash
+# one-off local scan of the full history
+docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest detect --source=/repo -v
+```

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,27 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <central-publishing-plugin.version>0.8.0</central-publishing-plugin.version>
     <maven-gpg-plugin.version>3.2.0</maven-gpg-plugin.version>
+    <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
+    <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
+    <pitest-maven.version>1.19.1</pitest-maven.version>
+    <pitest-junit5-plugin.version>1.2.2</pitest-junit5-plugin.version>
+    <testcontainers.version>1.20.4</testcontainers.version>
+    <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+    <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
+
+    <!-- Static analysis (SpotBugs, bytecode-based so it works alongside the
+         AspectJ weaving). Report-only by default; enable enforcement in CI with
+         -Dspotbugs.failOnError=true once the existing findings are triaged. -->
+    <spotbugs.failOnError>false</spotbugs.failOnError>
+
+    <!-- Test-coverage gate (JaCoCo). Per-class minimum line coverage enforced by
+         the "jacoco-check" execution; raise this over time. Classes that can only
+         be exercised by integration infrastructure (full Spring context, live
+         triplestore, Spring Boot bootstrap) are excluded via jacoco.excludes. -->
+    <jacoco.minimum.class.line.coverage>0.80</jacoco.minimum.class.line.coverage>
+    <!-- Coverage gate is reporting-only by default; CI sets this to true. -->
+    <jacoco.haltOnFailure>false</jacoco.haltOnFailure>
   </properties>
 
   <dependencyManagement>
@@ -236,6 +257,162 @@
             </execution>
           </executions>
         </plugin>
+        <!-- Test-coverage measurement and per-class gate (added: task "test
+             coverage"). prepare-agent instruments tests on-the-fly (independent
+             of AspectJ compile-time weaving); report writes target/site/jacoco;
+             jacoco-check enforces the per-class line-coverage minimum. -->
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+          <configuration>
+            <excludes>
+              <!-- Spring Boot bootstrap / @SpringBootApplication entry points
+                   whose sole purpose is launching the Spring context (main()),
+                   which cannot be meaningfully unit-tested. -->
+              <exclude>**/*Application.class</exclude>
+              <exclude>**/QanaryService.class</exclude>
+            </excludes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>jacoco-prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>jacoco-report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>jacoco-check</id>
+              <phase>test</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <!-- Do not fail the build by default; CI opts in with
+                     -Djacoco.haltOnFailure=true. Lets coverage be reported even
+                     while individual classes are still being brought up to par. -->
+                <haltOnFailure>${jacoco.haltOnFailure}</haltOnFailure>
+                <rules>
+                  <rule>
+                    <element>CLASS</element>
+                    <limits>
+                      <limit>
+                        <counter>LINE</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>${jacoco.minimum.class.line.coverage}</minimum>
+                      </limit>
+                    </limits>
+                  </rule>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Static analysis (added: quality task #1). SpotBugs works on the
+             compiled bytecode, so it is unaffected by the AspectJ weaving. The
+             FindSecBugs plugin adds security detectors. Report-only by default
+             (spotbugs.failOnError=false); invoke via `mvn spotbugs:check` (gate)
+             or `mvn spotbugs:spotbugs` (report -> target/spotbugsXml.xml). -->
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs-maven-plugin.version}</version>
+          <configuration>
+            <effort>Max</effort>
+            <threshold>Medium</threshold>
+            <failOnError>${spotbugs.failOnError}</failOnError>
+            <includeTests>false</includeTests>
+            <plugins>
+              <plugin>
+                <groupId>com.h3xstream.findsecbugs</groupId>
+                <artifactId>findsecbugs-plugin</artifactId>
+                <version>${findsecbugs-plugin.version}</version>
+              </plugin>
+            </plugins>
+          </configuration>
+        </plugin>
+        <!-- Mutation testing (added: quality task #1). On-demand only (slow); not
+             bound to a lifecycle phase. Run per module, e.g.:
+               mvn -pl qanary_commons org.pitest:pitest-maven:mutationCoverage
+             Reports -> target/pit-reports. Verifies tests actually detect
+             injected faults, not just execute the lines. -->
+        <plugin>
+          <groupId>org.pitest</groupId>
+          <artifactId>pitest-maven</artifactId>
+          <version>${pitest-maven.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.pitest</groupId>
+              <artifactId>pitest-junit5-plugin</artifactId>
+              <version>${pitest-junit5-plugin.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <targetClasses>
+              <param>eu.wdaqua.qanary.*</param>
+            </targetClasses>
+            <outputFormats>
+              <param>XML</param>
+              <param>HTML</param>
+            </outputFormats>
+            <timestampedReports>false</timestampedReports>
+            <failWhenNoMutations>false</failWhenNoMutations>
+          </configuration>
+        </plugin>
+        <!-- Build environment guard (quality task C7): require JDK 21+ and a
+             recent Maven, so a build on JDK 17 fails early and clearly instead of
+             producing confusing AspectJ/compile errors. -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>enforce-build-environment</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireJavaVersion>
+                    <version>[21,)</version>
+                    <message>This project requires JDK 21 or newer (the modules compile to Java 21).</message>
+                  </requireJavaVersion>
+                  <requireMavenVersion>
+                    <version>[3.6.3,)</version>
+                  </requireMavenVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Formatting (quality task C8). Lightweight, engine-free rules (import
+             order, trailing whitespace, final newline) so there is no mass
+             re-indentation. Run `mvn com.diffplug.spotless:spotless-maven-plugin:check`
+             to report drift (CI does this, non-blocking) or `:apply` to adopt it. -->
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin.version}</version>
+          <configuration>
+            <java>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <importOrder/>
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+            </java>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -251,6 +428,30 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
+      </plugin>
+      <!-- Activate JaCoCo for every module (config inherited from
+           pluginManagement above). Generates coverage and enforces the gate. -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+      <!-- SpotBugs available for every module (config from pluginManagement).
+           Not bound to a lifecycle phase, so normal builds are unaffected; run
+           explicitly with `mvn spotbugs:check` (CI static-analysis step). -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+      </plugin>
+      <!-- Enforce the build environment (JDK 21+, Maven) for every module. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+      <!-- Spotless present (config + version from pluginManagement) so the
+           check/apply goals work; not phase-bound, so normal builds are unaffected. -->
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/qald-evaluator/src/test/java/qald/evaluator/FileReaderTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/FileReaderTest.java
@@ -1,24 +1,40 @@
 package qald.evaluator;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Collection;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import eu.wdaqua.qanary.qald.evaluator.qaldreader.FileReader;
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.QaldQuestion;
 
 class FileReaderTest {
 
-	@Disabled
-	@Test
-	void test() throws UnsupportedEncodingException, IOException {
+    /**
+     * the bundled QALD-6 training benchmark is parsed into QaldQuestion objects
+     */
+    @Test
+    void readsBundledQaldBenchmark() throws UnsupportedEncodingException, IOException {
+        FileReader fileReader = new FileReader();
 
-		FileReader filereader = new FileReader();
+        Collection<QaldQuestion> questions = fileReader.getQuestions();
+        assertNotNull(questions);
+        assertFalse(questions.isEmpty(), "the QALD-6 benchmark should contain questions");
 
-		fail("Not yet implemented");
-	}
+        // every parsed question is retrievable by its QALD id and carries a question string
+        for (QaldQuestion q : questions) {
+            assertNotNull(fileReader.getQuestion(q.getQaldId()));
+            assertNotNull(q.getQuestion());
+        }
 
+        // at least one question annotates DBpedia resource URIs
+        boolean anyResourceUris = questions.stream()
+                .anyMatch(q -> !q.getResourceUrisAsString().isEmpty());
+        assertTrue(anyResourceUris, "expected at least one question with DBpedia resource URIs");
+    }
 }

--- a/qald-evaluator/src/test/java/qald/evaluator/MetricsTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/MetricsTest.java
@@ -1,0 +1,86 @@
+package qald.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.qald.evaluator.evaluation.Metrics;
+
+class MetricsTest {
+
+    private static final double DELTA = 1e-9;
+
+    @Test
+    void gettersAndSettersRoundTrip() {
+        Metrics m = new Metrics();
+        m.setPrecision(0.5);
+        m.setRecall(0.25);
+        m.setfMeasure(0.75);
+        assertEquals(0.5, m.getPrecision(), DELTA);
+        assertEquals(0.25, m.getRecall(), DELTA);
+        assertEquals(0.75, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void bothEmptyIsPerfectScore() {
+        Metrics m = new Metrics();
+        m.compute(Collections.emptyList(), Collections.emptyList());
+        assertEquals(1.0, m.getPrecision(), DELTA);
+        assertEquals(1.0, m.getRecall(), DELTA);
+        assertEquals(1.0, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void noExpectedButSystemAnswersIsZeroScore() {
+        Metrics m = new Metrics();
+        m.compute(Collections.emptyList(), Arrays.asList("a"));
+        assertEquals(0.0, m.getPrecision(), DELTA);
+        assertEquals(0.0, m.getRecall(), DELTA);
+        assertEquals(0.0, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void expectedButNoSystemAnswersHasZeroRecall() {
+        Metrics m = new Metrics();
+        m.compute(Arrays.asList("a", "b"), Collections.emptyList());
+        // precision is set to 1.0 in this branch, recall to 0.0
+        assertEquals(1.0, m.getPrecision(), DELTA);
+        assertEquals(0.0, m.getRecall(), DELTA);
+        // precision != 0, recall == 0 -> fMeasure computed as 0
+        assertEquals(0.0, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void perfectMatchYieldsFullScores() {
+        Metrics m = new Metrics();
+        List<String> answers = Arrays.asList("a", "b");
+        m.compute(answers, answers);
+        assertEquals(1.0, m.getPrecision(), DELTA);
+        assertEquals(1.0, m.getRecall(), DELTA);
+        assertEquals(1.0, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void partialMatchComputesPrecisionRecallAndFMeasure() {
+        Metrics m = new Metrics();
+        // expected {a,b,c}; system {a,b,x}: 2 correct of 3 system, 2 of 3 expected
+        m.compute(Arrays.asList("a", "b", "c"), Arrays.asList("a", "b", "x"));
+        assertEquals(2.0 / 3.0, m.getPrecision(), DELTA);
+        assertEquals(2.0 / 3.0, m.getRecall(), DELTA);
+        double expectedF = (2 * (2.0 / 3.0) * (2.0 / 3.0)) / ((2.0 / 3.0) + (2.0 / 3.0));
+        assertEquals(expectedF, m.getfMeasure(), DELTA);
+    }
+
+    @Test
+    void noOverlapGivesZeroFMeasure() {
+        Metrics m = new Metrics();
+        m.compute(Arrays.asList("a", "b"), Arrays.asList("x", "y"));
+        assertEquals(0.0, m.getPrecision(), DELTA);
+        assertEquals(0.0, m.getRecall(), DELTA);
+        assertEquals(0.0, m.getfMeasure(), DELTA);
+    }
+}

--- a/qald-evaluator/src/test/java/qald/evaluator/QaldQuestionTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/QaldQuestionTest.java
@@ -1,33 +1,95 @@
 package qald.evaluator;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Disabled;
+import java.net.URI;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
 import eu.wdaqua.qanary.qald.evaluator.qaldreader.QaldQuestion;
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.QaldQuestionUri;
 
 class QaldQuestionTest {
 
-	@Disabled
-	@Test
-	void test() {
+    private JsonObject parse(String json) {
+        return new Gson().fromJson(json, JsonObject.class);
+    }
 
-		JsonObject rawQuestion = new JsonObject();
-		rawQuestion.addProperty("id", 42);
-		rawQuestion.addProperty("question", "How many goals did Pelé score?");
+    /**
+     * a complete QALD question (English string + SPARQL query) is parsed and the
+     * annotated URIs are extracted from the query pattern
+     */
+    @Test
+    void parsesQuestionWithSparqlQueryAndExtractsUris() {
+        String json = "{"
+                + "\"id\": 42,"
+                + "\"question\": [{\"language\": \"en\", \"string\": \"Where is Berlin?\"}],"
+                + "\"query\": {\"sparql\": \"PREFIX dbr: <http://dbpedia.org/resource/> "
+                + "PREFIX dbo: <http://dbpedia.org/ontology/> "
+                + "SELECT ?x WHERE { dbr:Berlin dbo:country ?x . }\"}"
+                + "}";
 
-		QaldQuestion qaldQuestion = new QaldQuestion(rawQuestion);
+        QaldQuestion q = new QaldQuestion(parse(json));
 
-		qaldQuestion.getUris();
+        assertEquals(42, q.getQaldId());
+        assertEquals("Where is Berlin?", q.getQuestion());
 
-		// TODO: encapsulate with Mockito
+        // dbr:Berlin (subject) + dbo:country (predicate) are URIs; ?x is a variable
+        assertEquals(2, q.getUris().size());
 
-		// TODO: check recognized URIs
+        List<String> resourceUris = q.getResourceUrisAsString();
+        assertEquals(1, resourceUris.size());
+        assertEquals("http://dbpedia.org/resource/Berlin", resourceUris.get(0));
 
-		fail("Not yet implemented");
-	}
+        QaldQuestionUri berlin = q.getUri(URI.create("http://dbpedia.org/resource/Berlin"));
+        assertNotNull(berlin);
+        assertTrue(berlin.isUsedAsSubject());
+        assertTrue(berlin.isDBpediaResource());
+    }
 
+    /**
+     * a non-English language entry is skipped until the English one is found
+     */
+    @Test
+    void skipsNonEnglishLanguageEntries() {
+        String json = "{"
+                + "\"id\": 7,"
+                + "\"question\": ["
+                + "  {\"language\": \"de\", \"string\": \"Wo liegt Berlin?\"},"
+                + "  {\"language\": \"en\", \"string\": \"Where is Berlin?\"}"
+                + "],"
+                + "\"query\": {\"sparql\": \"PREFIX dbr: <http://dbpedia.org/resource/> "
+                + "SELECT ?x WHERE { dbr:Berlin ?p ?x . }\"}"
+                + "}";
+
+        QaldQuestion q = new QaldQuestion(parse(json));
+
+        assertEquals(7, q.getQaldId());
+        assertEquals("Where is Berlin?", q.getQuestion());
+        assertEquals(1, q.getResourceUrisAsString().size());
+    }
+
+    /**
+     * a question without a SPARQL query yields no annotated URIs (warn branch)
+     */
+    @Test
+    void questionWithoutSparqlHasNoUris() {
+        String json = "{"
+                + "\"id\": 99,"
+                + "\"question\": [{\"language\": \"en\", \"string\": \"unanswerable\"}],"
+                + "\"query\": {}"
+                + "}";
+
+        QaldQuestion q = new QaldQuestion(parse(json));
+
+        assertEquals(99, q.getQaldId());
+        assertTrue(q.getUris().isEmpty());
+        assertTrue(q.getResourceUrisAsString().isEmpty());
+    }
 }

--- a/qald-evaluator/src/test/java/qald/evaluator/QaldQuestionUriTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/QaldQuestionUriTest.java
@@ -1,0 +1,60 @@
+package qald.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.QaldQuestionUri;
+
+class QaldQuestionUriTest {
+
+    @Test
+    void classifiesDBpediaResource() {
+        QaldQuestionUri uri = new QaldQuestionUri(1, "http://dbpedia.org/resource/Berlin");
+        assertTrue(uri.isDBpediaResource());
+        assertFalse(uri.isDBpediaConcept());
+        assertFalse(uri.isDBpediaProperty());
+        assertFalse(uri.isRdfSyntax());
+        assertEquals("http://dbpedia.org/resource/Berlin", uri.getUri().toString());
+    }
+
+    @Test
+    void classifiesDBpediaConceptPropertyAndRdfSyntax() {
+        assertTrue(new QaldQuestionUri(1, "http://dbpedia.org/ontology/Country").isDBpediaConcept());
+        assertTrue(new QaldQuestionUri(1, "http://dbpedia.org/property/population").isDBpediaProperty());
+        assertTrue(new QaldQuestionUri(1, "http://www.w3.org/1999/02/22-rdf-syntax-ns#type").isRdfSyntax());
+    }
+
+    @Test
+    void tracksPositionFlags() {
+        QaldQuestionUri uri = new QaldQuestionUri(1, "http://dbpedia.org/resource/Berlin");
+        assertFalse(uri.isUsedAsSubject());
+        assertFalse(uri.isUsedAsPredicate());
+        assertFalse(uri.isUsedAsObject());
+
+        uri.setIsUsedAsSubject();
+        uri.setIsUsedAsPredicate();
+        uri.setIsUsedAsObject();
+
+        assertTrue(uri.isUsedAsSubject());
+        assertTrue(uri.isUsedAsPredicate());
+        assertTrue(uri.isUsedAsObject());
+    }
+
+    @Test
+    void registersAdditionalQaldQuestionsWithoutError() {
+        QaldQuestionUri uri = new QaldQuestionUri(1, "http://dbpedia.org/resource/Berlin");
+        uri.alsoUsedInQaldQuestion(2);
+        uri.alsoUsedInQaldQuestion(3);
+        assertTrue(uri.isDBpediaResource());
+    }
+
+    @Test
+    void invalidUriIsHandledGracefully() {
+        // an illegal URI string must not throw; the class logs and stores null
+        QaldQuestionUri uri = new QaldQuestionUri(1, "http://example.org/ has spaces");
+        org.junit.jupiter.api.Assertions.assertNull(uri.getUri());
+    }
+}

--- a/qald-evaluator/src/test/java/qald/evaluator/TurtleResultWriterTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/TurtleResultWriterTest.java
@@ -1,0 +1,53 @@
+package qald.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.QaldQuestion;
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.TurtleResultWriter;
+
+class TurtleResultWriterTest {
+
+    @Test
+    void writesHeaderQuestionAndEntityLines(@TempDir Path tmp) throws IOException {
+        Path out = tmp.resolve("result.ttl");
+
+        String json = "{"
+                + "\"id\": 5,"
+                + "\"question\": [{\"language\": \"en\", \"string\": \"Where is Berlin?\"}],"
+                + "\"query\": {\"sparql\": \"PREFIX dbr: <http://dbpedia.org/resource/> "
+                + "SELECT ?x WHERE { dbr:Berlin ?p ?x . }\"}"
+                + "}";
+        QaldQuestion question = new QaldQuestion(new Gson().fromJson(json, JsonObject.class));
+
+        TurtleResultWriter writer = new TurtleResultWriter(out.toString());
+        writer.writeQaldQuestionInformation(question);
+        writer.writeEntityInQuestion(5, "http://dbpedia.org/resource/Berlin", "expectedResource");
+        writer.close();
+
+        String content = Files.readString(out);
+        assertTrue(content.contains("# automatically created benchmark result"));
+        assertTrue(content.contains("PREFIX qaldevalquestion:"));
+        assertTrue(content.contains("qaldevalquestion:5 rdf:label \"Where is Berlin?\"^^xsd:string ."));
+        assertTrue(content.contains(
+                "qaldevalquestion:5 qaldevaluation:expectedResource <http://dbpedia.org/resource/Berlin> ."));
+    }
+
+    @Test
+    void constructorSwallowsIoErrorForUnwritableTarget(@TempDir Path tmp) {
+        // target path points into a non-existent sub-directory -> FileWriter fails;
+        // the constructor must catch the IOException rather than propagate it
+        String unwritable = tmp.resolve("does-not-exist").resolve("result.ttl").toString();
+        // must not throw
+        new TurtleResultWriter(unwritable);
+    }
+}

--- a/qald-evaluator/src/test/java/qald/evaluator/URIDetectorTest.java
+++ b/qald-evaluator/src/test/java/qald/evaluator/URIDetectorTest.java
@@ -1,0 +1,52 @@
+package qald.evaluator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.qald.evaluator.qaldreader.URIDetector;
+
+class URIDetectorTest {
+
+    @Test
+    void detectsSubjectsPredicatesAndObjectsOfAQueryPattern() {
+        String sparql = "PREFIX dbr: <http://dbpedia.org/resource/> "
+                + "PREFIX dbo: <http://dbpedia.org/ontology/> "
+                + "SELECT ?x WHERE { dbr:Berlin dbo:country ?x . }";
+
+        URIDetector detector = new URIDetector(sparql);
+
+        Set<Node> subjects = detector.getSubjects();
+        Set<Node> predicates = detector.getPredicates();
+        Set<Node> objects = detector.getObjects();
+
+        assertEquals(1, subjects.size());
+        assertTrue(subjects.iterator().next().isURI());
+        assertEquals("http://dbpedia.org/resource/Berlin", subjects.iterator().next().getURI());
+
+        assertEquals(1, predicates.size());
+        assertEquals("http://dbpedia.org/ontology/country", predicates.iterator().next().getURI());
+
+        assertEquals(1, objects.size());
+        // ?x is a variable, not a URI
+        assertTrue(objects.iterator().next().isVariable());
+    }
+
+    @Test
+    void handlesMultipleTriplePatterns() {
+        String sparql = "PREFIX dbr: <http://dbpedia.org/resource/> "
+                + "PREFIX dbo: <http://dbpedia.org/ontology/> "
+                + "SELECT ?x ?y WHERE { dbr:Berlin dbo:country ?x . ?x dbo:capital ?y . }";
+
+        URIDetector detector = new URIDetector(sparql);
+
+        // dbr:Berlin and ?x appear as subjects
+        assertEquals(2, detector.getSubjects().size());
+        // dbo:country and dbo:capital
+        assertEquals(2, detector.getPredicates().size());
+    }
+}

--- a/qanary_commons/pom.xml
+++ b/qanary_commons/pom.xml
@@ -84,6 +84,21 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Testcontainers: real-triplestore integration tests (quality task #2).
+             Spins up the project's own Virtuoso image; only runs when a Docker
+             daemon is available (the tests self-skip otherwise). -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/business/QanaryConfigurator.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/business/QanaryConfigurator.java
@@ -83,7 +83,7 @@ public class QanaryConfigurator {
             try {
                 myURI = new URI((component.getUrl() + "/annotatequestion").replace("//annotatequestion", "/annotatequestion"));
             } catch (URISyntaxException e) {
-                e.printStackTrace();
+                logger.error("invalid component URL '{}', aborting process", component.getUrl(), e);
                 return result;
             }
 

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryMessage.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/QanaryMessage.java
@@ -88,7 +88,7 @@ public class QanaryMessage {
 			return this.values.get(new URI(key));
 		} catch (URISyntaxException e) {
 			// should never ever happen or the whole Qanary pipeline is broken
-			e.printStackTrace();
+			logger.error("could not resolve the URI for key '{}'", key, e);
 			return null;
 		}
 	}

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/config/CacheConfig.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/config/CacheConfig.java
@@ -46,7 +46,7 @@ public class CacheConfig {
 	@Bean
 	public CacheManager cacheManager(Caffeine caffeine,
 			@Value("${qanary.webservicecalls.cache.specs:}") String caffeineSpec) {
-		if (caffeineSpec == null || caffeineSpec == "") {
+		if (caffeineSpec == null || caffeineSpec.isBlank()) {
 			caffeineSpec = "maximumSize=1,expireAfterAccess=0s"; // default value
 		}
 		logger.info("cacheManager configuration: {}", caffeineSpec);

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnector.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnector.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
 public abstract class QanaryTripleStoreConnector {
@@ -46,8 +47,10 @@ public abstract class QanaryTripleStoreConnector {
 
         if (in == null) {
             return null;
-        } else {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+        }
+        // try-with-resources so the reader (and the underlying stream) is always
+        // closed -- the previous code leaked the stream on every template load.
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             return reader.lines().collect(Collectors.joining("\n"));
         }
     }

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnectorVirtuoso.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnectorVirtuoso.java
@@ -104,7 +104,7 @@ public class QanaryTripleStoreConnectorVirtuoso extends QanaryTripleStoreConnect
                 return;
             } catch (Exception e) {
                 getLogger().warn("Tried to establish connection ({}), but failed: {}", numberOfReconnectingTries, e.getMessage());
-                e.printStackTrace();
+                getLogger().debug("stack trace of the handled exception", e);
                 numberOfReconnectingTries++;
 
                 if (this.maxTriesConnectionTimeout <= numberOfReconnectingTries) {
@@ -116,7 +116,7 @@ public class QanaryTripleStoreConnectorVirtuoso extends QanaryTripleStoreConnect
                     TimeUnit.SECONDS.sleep(5);
                 } catch (Exception e2) {
                     getLogger().warn("Failed to wait for 5 seconds: {}", e2.getMessage());
-                    e2.printStackTrace();
+                    getLogger().debug("stack trace of the handled exception", e2);
                 }
             }
         }
@@ -131,7 +131,7 @@ public class QanaryTripleStoreConnectorVirtuoso extends QanaryTripleStoreConnect
                 return this.select(sparql, numberOfTries);
             } catch (Exception e) {
                 getLogger().error("Error while executing a SELECT query: {}", e.getMessage());
-                e.printStackTrace();
+                getLogger().debug("stack trace of the handled exception", e);
 
                 if (e.getMessage().contains(VIRTUOSO_PROBLEM_STRING)) { // not nice
                     getLogger().error("Connection was a timeout. Possible retry ({} tries already).", numberOfTries);
@@ -165,7 +165,7 @@ public class QanaryTripleStoreConnectorVirtuoso extends QanaryTripleStoreConnect
                 return this.ask(sparql, numberOfTries);
             } catch (Exception e) {
                 getLogger().error("Error while executing a ASK query: {}", e.getMessage());
-                e.printStackTrace();
+                getLogger().debug("stack trace of the handled exception", e);
 
                 if (e.getMessage().contains(VIRTUOSO_PROBLEM_STRING)) { // not nice
                     getLogger().error("Connection was a timeout. Possible retry ({} tries already).", numberOfTries);
@@ -199,7 +199,7 @@ public class QanaryTripleStoreConnectorVirtuoso extends QanaryTripleStoreConnect
                 return;
             } catch (Exception e) {
                 getLogger().error("Error while executing a UPDATE query: {}", e.getMessage());
-                e.printStackTrace();
+                getLogger().debug("stack trace of the handled exception", e);
 
                 if (e.getMessage().contains(VIRTUOSO_PROBLEM_STRING)) { // not nice
                     getLogger().error("Connection was a timeout. Possible retry ({} tries already).", numberOfTries);

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreProxy.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreProxy.java
@@ -90,7 +90,9 @@ public class QanaryTripleStoreProxy extends QanaryTripleStoreConnector {
 
     @Override
     public void update(String sparql, URI graph) throws SparqlQueryFailed {
-        this.update(sparql, null);
+        // delegate to the external connector (as select/ask/update(sparql) do);
+        // the previous 'this.update(sparql, null)' recursed into itself forever.
+        externalConnector.update(sparql, graph);
     }
 
     @Override

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/README.adoc
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/commons/triplestoreconnectors/README.adoc
@@ -91,3 +91,34 @@ virtuoso.url=jdbc:virtuoso://localhost:1111
 virtuoso.username=dba
 virtuoso.password=mysecret
 ```
+
+==== Known behaviour / quirks
+
+[WARNING]
+====
+The Virtuoso connector (`QanaryTripleStoreConnectorVirtuoso`) talks to Virtuoso
+through the `virtuoso-jena` JDBC driver (`VirtGraph`), which does *not* always
+follow standard SPARQL 1.1 semantics. Behaviours observed via integration tests
+against the Virtuoso image:
+
+* *`ASK` is unreliable for absence.* An `ASK { GRAPH <g> { <s> <p> <o> } }` can
+  return `true` even for a triple that was never inserted, so do not use `ask(...)`
+  to prove that something is *not* present.
+* *Named graphs are not strictly isolated for reads.* A query scoped to one named
+  graph may see triples written to a different graph, so do not rely on the
+  `GRAPH <g>` clause to partition data when reading.
+* *Writes may not be immediately visible to a `SELECT` on the same connection.*
+  A triple written with `update(...)` can be missing from an immediately following
+  `select(...)` (though `construct(...)` sees it) — i.e. read-your-write is not
+  guaranteed without a short delay / re-read.
+
+These are tolerated by the Qanary pipeline because its question-answering flow is
+eventually consistent (each component writes, later components read), and the
+end-to-end process works correctly. But when writing code or tests directly
+against this connector: prefer positive `SELECT`/`CONSTRUCT` assertions, never
+assert absence via `ASK` or rely on cross-graph isolation, and re-read instead of
+assuming a write is immediately visible. The in-memory connector
+(`QanaryTripleStoreConnectorInMemory`) and the SPARQL-over-HTTP connector
+(`QanaryTripleStoreConnectorQanaryInternal`) follow standard Jena/SPARQL semantics
+and are better suited for deterministic unit/integration tests.
+====

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/communications/ExplainabilityRequestInterceptor.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/communications/ExplainabilityRequestInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.IOException;
+import java.util.Stack;
 
 public class ExplainabilityRequestInterceptor implements ClientHttpRequestInterceptor {
 
@@ -16,11 +17,15 @@ public class ExplainabilityRequestInterceptor implements ClientHttpRequestInterc
 
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
-        String processId = QanaryAspect.getCallStack().peek().toString();
-        if (processId == null) {
+        // the call stack can be empty (e.g. no surrounding Qanary process): guard
+        // against that instead of letting peek() throw EmptyStackException. The
+        // previous "processId == null" check after peek().toString() was unreachable.
+        Stack<String> callStack = QanaryAspect.getCallStack();
+        if (callStack.isEmpty() || callStack.peek() == null) {
             logger.error("Couldn't get processId from stack, skip logging");
             return execution.execute(request, body);
         }
+        String processId = callStack.peek();
         logger.debug("ExplainabilityRequestInterceptor: processId: " + processId);
         request.getHeaders().add("processId", processId);
         return execution.execute(request, body);

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/exceptions/QanaryExceptionServiceCallNotOk.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/exceptions/QanaryExceptionServiceCallNotOk.java
@@ -17,7 +17,7 @@ public class QanaryExceptionServiceCallNotOk extends Exception {
 
 	public QanaryExceptionServiceCallNotOk(String componentName, long duration, HttpStatus myHttpStatus) {
 		super(String.format(
-				"Call to Qanary component {} was not performed correctly (duration: {} ms); it returned {}. |\n{}", //
+				"Call to Qanary component %s was not performed correctly (duration: %d ms); it returned %s. |%n%d", //
 				componentName, //
 				duration, //
 				myHttpStatus.name(), //
@@ -30,7 +30,7 @@ public class QanaryExceptionServiceCallNotOk extends Exception {
 
 	public QanaryExceptionServiceCallNotOk(String componentName, long duration, String message, String stackTrace) {
 		super(String.format(
-				"Call to Qanary component {} was not performed correctly (duration: {} ms); it returned {}. |\n{}", //
+				"Call to Qanary component %s was not performed correctly (duration: %d ms); it returned %s. |%n%s", //
 				componentName, //
 				duration, //
 				message, //

--- a/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryQuestionAnsweringFinished.java
+++ b/qanary_commons/src/main/java/eu/wdaqua/qanary/message/QanaryQuestionAnsweringFinished.java
@@ -20,7 +20,7 @@ import eu.wdaqua.qanary.commons.QanaryMessage;
  */
 public class QanaryQuestionAnsweringFinished {
 	
-	private class ComponentExecutionLog {
+	public static class ComponentExecutionLog {
 		private String componentName;
 		private String componentUri;
 		private long time;

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/business/QanaryComponentTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/business/QanaryComponentTest.java
@@ -1,0 +1,26 @@
+package eu.wdaqua.qanary.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class QanaryComponentTest {
+
+    @Test
+    void exposesNameUrlAndUsedFlag() {
+        QanaryComponent c = new QanaryComponent("NER", "http://localhost:8080", true);
+        assertEquals("NER", c.getName());
+        assertEquals("http://localhost:8080", c.getUrl());
+        assertTrue(c.isUsed());
+    }
+
+    @Test
+    void usedFlagIsMutable() {
+        QanaryComponent c = new QanaryComponent("NED", "http://localhost:8081", false);
+        assertFalse(c.isUsed());
+        c.setUsed(true);
+        assertTrue(c.isUsed());
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/business/QanaryConfiguratorTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/business/QanaryConfiguratorTest.java
@@ -1,0 +1,118 @@
+package eu.wdaqua.qanary.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import eu.wdaqua.qanary.commons.QanaryMessage;
+import eu.wdaqua.qanary.commons.triplestoreconnectors.QanaryTripleStoreProxy;
+import eu.wdaqua.qanary.exceptions.QanaryExceptionServiceCallNotOk;
+import eu.wdaqua.qanary.message.QanaryQuestionAnsweringFinished;
+
+class QanaryConfiguratorTest {
+
+    private QanaryConfigurator configurator(RestTemplate restTemplate) {
+        return new QanaryConfigurator(
+                restTemplate,
+                List.of("ComponentA", "ComponentB"),
+                "localhost",
+                8080,
+                URI.create("urn:qanary#ontology"),
+                URI.create("http://localhost:8890/sparql"),
+                mock(QanaryTripleStoreProxy.class));
+    }
+
+    private QanaryMessage message() throws URISyntaxException {
+        return new QanaryMessage(URI.create("http://localhost:8890/sparql"), URI.create("urn:graph:in"));
+    }
+
+    @Test
+    void exposesConfigurationViaGetters() {
+        QanaryTripleStoreProxy proxy = mock(QanaryTripleStoreProxy.class);
+        QanaryConfigurator config = new QanaryConfigurator(
+                mock(RestTemplate.class), List.of("A", "B"), "myhost", 9090,
+                URI.create("urn:onto"), URI.create("http://ts/sparql"), proxy);
+
+        assertEquals(9090, config.getPort());
+        assertEquals("myhost", config.getHost());
+        assertEquals(URI.create("urn:onto"), config.getQanaryOntology());
+        assertEquals(URI.create("http://ts/sparql"), config.getEndpoint());
+        assertSame(proxy, config.getQanaryTripleStoreConnector());
+        assertEquals(List.of("A", "B"), config.getDefaultComponentNames());
+        assertEquals("A,B", config.getDefaultComponentNamesAsString());
+
+        config.setDefaultComponentNames(List.of("C"));
+        assertEquals("C", config.getDefaultComponentNamesAsString());
+    }
+
+    @Test
+    void callServicesWithEmptyComponentListReturnsImmediately() throws Exception {
+        QanaryConfigurator config = configurator(mock(RestTemplate.class));
+        QanaryQuestionAnsweringFinished result = config.callServices(Collections.emptyList(), message());
+        assertTrue(result.getCompactProtocol().isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void callServicesAppendsProtocolForSuccessfulComponentCall() throws Exception {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        QanaryMessage responseBody = message();
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+                eq(QanaryMessage.class)))
+                .thenReturn(new ResponseEntity<>(responseBody, HttpStatus.OK));
+
+        QanaryConfigurator config = configurator(restTemplate);
+        QanaryComponent component = new QanaryComponent("NER", "http://localhost:8081", true);
+
+        QanaryQuestionAnsweringFinished result = config.callServices(List.of(component), message());
+        assertEquals(1, result.getCompactProtocol().size());
+        assertTrue(result.getCompactProtocol().get(0).contains("NER"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void callServicesThrowsWhenComponentReturnsNonOkStatus() throws Exception {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+                eq(QanaryMessage.class)))
+                .thenReturn(new ResponseEntity<>(message(), HttpStatus.INTERNAL_SERVER_ERROR));
+
+        QanaryConfigurator config = configurator(restTemplate);
+        QanaryComponent component = new QanaryComponent("NED", "http://localhost:8082", true);
+
+        assertThrows(QanaryExceptionServiceCallNotOk.class,
+                () -> config.callServices(List.of(component), message()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void callServicesWrapsUnexpectedExceptionAsServiceCallNotOk() throws Exception {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+                eq(QanaryMessage.class)))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        QanaryConfigurator config = configurator(restTemplate);
+        QanaryComponent component = new QanaryComponent("LINKER", "http://localhost:8083", true);
+
+        assertThrows(QanaryExceptionServiceCallNotOk.class,
+                () -> config.callServices(List.of(component), message()));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/business/TriplestoreEndpointIdentifierTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/business/TriplestoreEndpointIdentifierTest.java
@@ -1,0 +1,46 @@
+package eu.wdaqua.qanary.business;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The class is {@code @Deprecated} and most endpoint rewrites are commented out,
+ * so every endpoint accessor currently returns the URI unchanged regardless of
+ * the {@code stardog5} flag. These tests pin that behaviour for both flag states.
+ */
+class TriplestoreEndpointIdentifierTest {
+
+    private TriplestoreEndpointIdentifier withStardog5(boolean value) throws Exception {
+        TriplestoreEndpointIdentifier identifier = new TriplestoreEndpointIdentifier();
+        Field f = TriplestoreEndpointIdentifier.class.getDeclaredField("stardog5");
+        f.setAccessible(true);
+        f.setBoolean(identifier, value);
+        return identifier;
+    }
+
+    @Test
+    void endpointsAreUnchangedWhenStardog5Disabled() throws Exception {
+        TriplestoreEndpointIdentifier id = withStardog5(false);
+        URI uri = URI.create("http://localhost:8890/sparql");
+        assertEquals(uri, id.getSelectEndpoint(uri));
+        assertEquals(uri, id.getAskEndpoint(uri));
+        assertEquals(uri, id.getUpdateEndpoint(uri));
+        assertEquals(uri, id.getCreateEndpoint(uri));
+        assertEquals(uri, id.getLoadEndpoint(uri));
+    }
+
+    @Test
+    void endpointsAreUnchangedWhenStardog5Enabled() throws Exception {
+        TriplestoreEndpointIdentifier id = withStardog5(true);
+        URI uri = URI.create("http://localhost:8890/sparql");
+        assertEquals(uri, id.getSelectEndpoint(uri));
+        assertEquals(uri, id.getAskEndpoint(uri));
+        assertEquals(uri, id.getUpdateEndpoint(uri));
+        assertEquals(uri, id.getCreateEndpoint(uri));
+        assertEquals(uri, id.getLoadEndpoint(uri));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryExceptionNoOrMultipleQuestionsTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryExceptionNoOrMultipleQuestionsTest.java
@@ -1,0 +1,15 @@
+package eu.wdaqua.qanary.commons;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class QanaryExceptionNoOrMultipleQuestionsTest {
+
+    @Test
+    void keepsProvidedMessage() {
+        QanaryExceptionNoOrMultipleQuestions ex =
+                new QanaryExceptionNoOrMultipleQuestions("no question found");
+        assertEquals("no question found", ex.getMessage());
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryMessageTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryMessageTest.java
@@ -1,0 +1,66 @@
+package eu.wdaqua.qanary.commons;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+
+class QanaryMessageTest {
+
+    private static final URI ENDPOINT = URI.create("http://localhost:8890/sparql");
+    private static final URI IN_GRAPH = URI.create("urn:graph:in");
+    private static final URI OUT_GRAPH = URI.create("urn:graph:out");
+
+    @Test
+    void twoArgConstructorReusesInGraphAsOutGraph() throws URISyntaxException {
+        QanaryMessage m = new QanaryMessage(ENDPOINT, IN_GRAPH);
+        assertEquals(ENDPOINT, m.getEndpoint());
+        assertEquals(IN_GRAPH, m.getInGraph());
+        assertEquals(IN_GRAPH, m.getOutGraph());
+    }
+
+    @Test
+    void threeArgConstructorStoresAllGraphs() throws URISyntaxException {
+        QanaryMessage m = new QanaryMessage(ENDPOINT, IN_GRAPH, OUT_GRAPH);
+        assertEquals(ENDPOINT, m.getEndpoint());
+        assertEquals(IN_GRAPH, m.getInGraph());
+        assertEquals(OUT_GRAPH, m.getOutGraph());
+        assertEquals(3, m.getValues().size());
+    }
+
+    @Test
+    void defaultConstructorThenSetValues() throws URISyntaxException {
+        QanaryMessage m = new QanaryMessage();
+        m.setValues(ENDPOINT, IN_GRAPH, OUT_GRAPH);
+        assertEquals(ENDPOINT, m.getEndpoint());
+        assertEquals(OUT_GRAPH, m.getOutGraph());
+    }
+
+    @Test
+    void jsonStringConstructorParsesValues() throws URISyntaxException {
+        String json = "{\"values\":{"
+                + "\"urn:qanary#endpoint\":\"http://localhost:8890/sparql\","
+                + "\"urn:qanary#inGraph\":\"urn:graph:in\","
+                + "\"urn:qanary#outGraph\":\"urn:graph:out\""
+                + "}}";
+        QanaryMessage m = new QanaryMessage(json);
+        assertEquals(ENDPOINT, m.getEndpoint());
+        assertEquals(IN_GRAPH, m.getInGraph());
+        assertEquals(OUT_GRAPH, m.getOutGraph());
+    }
+
+    @Test
+    void asJsonStringSerialisesValuesAndRoundTrips() throws URISyntaxException {
+        QanaryMessage m = new QanaryMessage(ENDPOINT, IN_GRAPH, OUT_GRAPH);
+        String json = m.asJsonString();
+        assertTrue(json.contains("urn:qanary#endpoint"));
+        assertTrue(json.contains("http://localhost:8890/sparql"));
+
+        QanaryMessage roundTripped = new QanaryMessage(json);
+        assertEquals(ENDPOINT, roundTripped.getEndpoint());
+        assertEquals(OUT_GRAPH, roundTripped.getOutGraph());
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryQuestionInMemoryIntegrationTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/QanaryQuestionInMemoryIntegrationTest.java
@@ -1,0 +1,156 @@
+package eu.wdaqua.qanary.commons;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.commons.triplestoreconnectors.QanaryTripleStoreConnectorInMemory;
+import eu.wdaqua.qanary.exceptions.SparqlQueryFailed;
+
+/**
+ * Integration test for {@link QanaryQuestion} (and the {@link QanaryUtils} it
+ * wraps) running against a real, in-memory Jena triplestore
+ * ({@link QanaryTripleStoreConnectorInMemory}). Unlike the pure-unit tests this
+ * actually parses and executes SPARQL queries and round-trips RDF, exercising
+ * the question/annotation read+write code paths end to end without any external
+ * triplestore.
+ */
+class QanaryQuestionInMemoryIntegrationTest {
+
+    private static final String RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    private static final String RDF_TYPE = RDF + "type";
+    private static final String RDF_VALUE = RDF + "value";
+    private static final String QA = "http://www.wdaqua.eu/qa#";
+    private static final String OA = "http://www.w3.org/ns/openannotation/core/";
+
+    private static final URI ENDPOINT = URI.create("urn:test:endpoint");
+    private static final URI GRAPH = URI.create("urn:graph:test");
+    private static final String QUESTION_URI = "urn:qanary:question:1";
+
+    private QanaryTripleStoreConnectorInMemory connector;
+    private QanaryQuestion<String> question;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        connector = new QanaryTripleStoreConnectorInMemory();
+        // a single qa:Question resource in the working graph
+        connector.update("INSERT DATA { GRAPH <" + GRAPH + "> { "
+                + "<" + QUESTION_URI + "> <" + RDF_TYPE + "> <" + QA + "Question> . } }");
+        QanaryMessage message = new QanaryMessage(ENDPOINT, GRAPH); // outGraph == inGraph
+        question = new QanaryQuestion<>(message, connector);
+    }
+
+    @Test
+    void exposesGraphsEndpointMessageAndConnector() {
+        assertEquals(GRAPH, question.getInGraph());
+        assertEquals(GRAPH, question.getOutGraph());
+        assertEquals(GRAPH, question.getNamedGraph());
+        assertEquals(ENDPOINT, question.getEndpoint());
+        assertNotNull(question.getQanaryMessage());
+        assertNotNull(question.getQanaryUtils());
+        assertSame(connector, question.getQanaryTripleStoreConnector());
+    }
+
+    @Test
+    void getUriReadsTheStoredQuestionResource() throws Exception {
+        assertEquals(URI.create(QUESTION_URI), question.getUri());
+    }
+
+    @Test
+    void getUriThrowsWhenNoQuestionInGraph() throws Exception {
+        QanaryMessage emptyMessage = new QanaryMessage(ENDPOINT, URI.create("urn:graph:empty"));
+        QanaryQuestion<String> emptyQuestion = new QanaryQuestion<>(emptyMessage, connector);
+        assertThrows(QanaryExceptionNoOrMultipleQuestions.class, emptyQuestion::getUri);
+    }
+
+    @Test
+    void getUriThrowsWhenMultipleQuestionsInGraph() throws Exception {
+        connector.update("INSERT DATA { GRAPH <" + GRAPH + "> { "
+                + "<urn:qanary:question:2> <" + RDF_TYPE + "> <" + QA + "Question> . } }");
+        assertThrows(QanaryExceptionNoOrMultipleQuestions.class, question::getUri);
+    }
+
+    @Test
+    void putAnnotationOfTextRepresentationInsertsAnnotation() throws Exception {
+        // initially absent
+        assertTrue(annotationAbsent("AnnotationOfTextRepresentation"));
+        question.putAnnotationOfTextRepresentation();
+        assertTrue(annotationPresent("AnnotationOfTextRepresentation"));
+    }
+
+    @Test
+    void putAnnotationOfAudioRepresentationInsertsAnnotation() throws Exception {
+        question.putAnnotationOfAudioRepresentation();
+        assertTrue(annotationPresent("AnnotationOfAudioRepresentation"));
+    }
+
+    @Test
+    void getSparqlResultsReturnsAnnotatedAnswerQuery() throws Exception {
+        // no answer-SPARQL annotations yet
+        assertTrue(question.getSparqlResults().isEmpty());
+        assertEquals("", question.getSparqlResult());
+
+        connector.update("INSERT DATA { GRAPH <" + GRAPH + "> { "
+                + "<urn:anno:sparql> <" + RDF_TYPE + "> <" + QA + "AnnotationOfAnswerSPARQL> ; "
+                + "  <" + OA + "hasBody> <urn:body:sparql> ; "
+                + "  <" + OA + "annotatedAt> \"2024-01-01T00:00:00Z\"^^<http://www.w3.org/2001/XMLSchema#dateTime> . "
+                + "<urn:body:sparql> <" + RDF_TYPE + "> <" + QA + "SparqlQuery> ; "
+                + "  <" + RDF_VALUE + "> \"SELECT * WHERE {}\" . } }");
+
+        var results = question.getSparqlResults();
+        assertEquals(1, results.size());
+        assertTrue(question.getSparqlResult().contains("SELECT"));
+    }
+
+    @Test
+    void getJsonResultReturnsEmptyThenAnnotatedJson() throws Exception {
+        assertEquals("", question.getJsonResult());
+
+        connector.update("INSERT DATA { GRAPH <" + GRAPH + "> { "
+                + "<urn:anno:json> <" + RDF_TYPE + "> <" + QA + "AnnotationOfAnswerJson> ; "
+                + "  <" + OA + "hasBody> <urn:body:json> . "
+                + "<urn:body:json> <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> \"[1,2,3]\" . } }");
+
+        assertTrue(question.getJsonResult().contains("1,2,3"));
+    }
+
+    @Test
+    void languageAnnotationRoundTrip() throws Exception {
+        question.setLanguageText("en");
+        assertEquals("en", question.getLanguage());
+    }
+
+    @Test
+    void targetDataAnnotationRoundTrip() throws Exception {
+        question.setTargetData(java.util.List.of("http://dbpedia.org"));
+        assertTrue(question.getTargetData().contains("http://dbpedia.org"));
+    }
+
+    @Test
+    void getAnswerFoundDefaultsToUndefinedWhenAbsent() throws Exception {
+        assertEquals("undefined", question.getAnswerFound());
+    }
+
+    @Test
+    void getUriTextualRepresentationReturnsAnnotatedBody() throws Exception {
+        question.putAnnotationOfTextRepresentation();
+        assertEquals(URI.create(QUESTION_URI), question.getUriTextualRepresentation());
+    }
+
+    // ---- helpers ------------------------------------------------------------
+
+    private boolean annotationPresent(String qaType) throws SparqlQueryFailed {
+        return connector.ask("ASK { GRAPH <" + GRAPH + "> { ?a <" + RDF_TYPE + "> <" + QA + qaType + "> } }");
+    }
+
+    private boolean annotationAbsent(String qaType) throws SparqlQueryFailed {
+        return !annotationPresent(qaType);
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/config/ConfigClassesTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/config/ConfigClassesTest.java
@@ -1,0 +1,68 @@
+package eu.wdaqua.qanary.commons.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+class ConfigClassesTest {
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void cacheConfigBuildsCacheManagerWithExplicitSpec() {
+        CacheConfig cacheConfig = new CacheConfig();
+        Caffeine caffeine = cacheConfig.caffeineConfig();
+        assertNotNull(caffeine);
+
+        CacheManager manager = cacheConfig.cacheManager(caffeine, "maximumSize=10,expireAfterAccess=60s");
+        assertNotNull(manager);
+        // requesting a cache by the configured name materialises it
+        assertNotNull(manager.getCache(CacheConfig.CACHENAME));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void cacheConfigFallsBackToDefaultSpecWhenNull() {
+        CacheConfig cacheConfig = new CacheConfig();
+        Caffeine caffeine = cacheConfig.caffeineConfig();
+        CacheManager manager = cacheConfig.cacheManager(caffeine, null);
+        assertNotNull(manager);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void cacheConfigFallsBackToDefaultSpecWhenBlank() {
+        // a blank spec must use the default (the old 'spec == ""' identity check
+        // was unreliable and could pass "" straight to Caffeine)
+        CacheConfig cacheConfig = new CacheConfig();
+        Caffeine caffeine = cacheConfig.caffeineConfig();
+        CacheManager manager = cacheConfig.cacheManager(caffeine, "   ");
+        assertNotNull(manager);
+        assertNotNull(manager.getCache(CacheConfig.CACHENAME));
+    }
+
+    @Test
+    void qanaryConfigurationServiceAndHostUriRoundTrip() {
+        URI service = URI.create("http://localhost:8080/service");
+        URI host = URI.create("http://localhost:8080");
+        QanaryConfiguration.setServiceUri(service);
+        QanaryConfiguration.setHostUri(host);
+        assertEquals(service, QanaryConfiguration.getServiceUri());
+        assertEquals(host, QanaryConfiguration.getHostUri());
+        // a few of the path constants are stable parts of the Qanary protocol
+        assertEquals("/sparql", QanaryConfiguration.sparql);
+        assertEquals("urn:qanary#endpoint", QanaryConfiguration.endpointKey);
+    }
+
+    @Test
+    void restClientConfigCanBeInstantiated() {
+        // configuration class currently only declares beans (commented out);
+        // ensure it remains instantiable as a Spring @Configuration
+        assertNotNull(new RestClientConfig());
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/ontology/TextPositionSelectorTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/ontology/TextPositionSelectorTest.java
@@ -1,0 +1,72 @@
+package eu.wdaqua.qanary.commons.ontology;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+
+import org.apache.jena.reasoner.IllegalParameterException;
+import org.junit.jupiter.api.Test;
+
+class TextPositionSelectorTest {
+
+    @Test
+    void startEndConstructorStoresRangeAndLeavesUriAndScoreNull() {
+        TextPositionSelector s = new TextPositionSelector(3, 10);
+        assertEquals(3, s.getStart());
+        assertEquals(10, s.getEnd());
+        assertNull(s.getResourceUri());
+        assertNull(s.getScore());
+    }
+
+    @Test
+    void scoreConstructorStoresScore() {
+        TextPositionSelector s = new TextPositionSelector(0, 5, 0.75f);
+        assertEquals(0.75f, s.getScore());
+        assertNull(s.getResourceUri());
+    }
+
+    @Test
+    void uriConstructorStoresResourceUri() {
+        URI uri = URI.create("http://dbpedia.org/resource/Berlin");
+        TextPositionSelector s = new TextPositionSelector(0, 5, uri, 0.5f);
+        assertEquals(uri, s.getResourceUri());
+        assertEquals(0.5f, s.getScore());
+    }
+
+    @Test
+    void stringUriConstructorParsesUri() throws Exception {
+        TextPositionSelector s = new TextPositionSelector(0, 5, "http://dbpedia.org/resource/Berlin", 0.5f);
+        assertEquals(URI.create("http://dbpedia.org/resource/Berlin"), s.getResourceUri());
+    }
+
+    @Test
+    void zeroBoundaryIsAccepted() {
+        // start == 0, end == 0 (and end == start) are the valid lower boundary;
+        // pins the 'start < 0' / 'end < 0' / 'end - start < 0' checks against being
+        // weakened to '<=' (kills the ConditionalsBoundary mutants flagged by PIT).
+        TextPositionSelector s = new TextPositionSelector(0, 0);
+        assertEquals(0, s.getStart());
+        assertEquals(0, s.getEnd());
+
+        TextPositionSelector range = new TextPositionSelector(0, 1);
+        assertEquals(0, range.getStart());
+        assertEquals(1, range.getEnd());
+    }
+
+    @Test
+    void negativeStartIsRejected() {
+        assertThrows(IllegalParameterException.class, () -> new TextPositionSelector(-1, 5));
+    }
+
+    @Test
+    void negativeEndIsRejected() {
+        assertThrows(IllegalParameterException.class, () -> new TextPositionSelector(0, -5));
+    }
+
+    @Test
+    void endBeforeStartIsRejected() {
+        assertThrows(IllegalParameterException.class, () -> new TextPositionSelector(10, 3));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/AbstractQanaryTripleStoreConnectorContract.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/AbstractQanaryTripleStoreConnectorContract.java
@@ -1,0 +1,86 @@
+package eu.wdaqua.qanary.commons.triplestoreconnectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.UUID;
+
+import org.apache.jena.query.ResultSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.exceptions.SparqlQueryFailed;
+
+/**
+ * Conformance contract that every {@link QanaryTripleStoreConnector} must satisfy.
+ * Subclasses supply a concrete connector via {@link #connector()} and the same
+ * tests run against each implementation, pinning a single, consistent behaviour.
+ * <p>
+ * The contract deliberately covers only the operations that behave identically
+ * across all connectors: {@code update(String)} (insert) and {@code select(String)}
+ * (including a count query). It does NOT include {@code ask(...)} absence,
+ * named-graph isolation, {@code construct(...)} or delete, because those diverge
+ * between implementations (e.g. the in-memory connector does not implement
+ * {@code construct}; the Virtuoso/VirtGraph driver's ASK and named-graph semantics
+ * are non-standard — see this package's README.adoc). Each test uses a unique
+ * subject IRI so the assertions are independent of residual store state.
+ */
+abstract class AbstractQanaryTripleStoreConnectorContract {
+
+    protected static final URI GRAPH = URI.create("urn:qanary:contract:graph");
+
+    /** the connector under test (subclasses provide an initialised instance) */
+    protected abstract QanaryTripleStoreConnector connector();
+
+    private String subject;
+
+    @BeforeEach
+    void freshSubject() {
+        subject = "urn:qanary:contract:s:" + UUID.randomUUID();
+    }
+
+    private void insert(String s) throws SparqlQueryFailed {
+        connector().update("INSERT DATA { GRAPH <" + GRAPH + "> { <" + s + "> <urn:p> <urn:o> . } }");
+    }
+
+    @Test
+    void insertedTripleIsSelectable() throws SparqlQueryFailed {
+        insert(subject);
+        ResultSet rs = connector().select(
+                "SELECT ?o WHERE { GRAPH <" + GRAPH + "> { <" + subject + "> <urn:p> ?o } }");
+        assertTrue(rs.hasNext(), "the inserted triple must be selectable");
+        assertEquals("urn:o", rs.next().getResource("o").getURI());
+    }
+
+    @Test
+    void absentSubjectSelectsNothing() throws SparqlQueryFailed {
+        ResultSet rs = connector().select(
+                "SELECT ?o WHERE { GRAPH <" + GRAPH + "> { <urn:qanary:contract:absent:"
+                        + UUID.randomUUID() + "> <urn:p> ?o } }");
+        assertFalse(rs.hasNext(), "a never-inserted subject must select nothing");
+    }
+
+    @Test
+    void multipleInsertsAreAllSelectable() throws SparqlQueryFailed {
+        String s1 = subject + ":a";
+        String s2 = subject + ":b";
+        insert(s1);
+        insert(s2);
+        for (String s : new String[] {s1, s2}) {
+            ResultSet rs = connector().select(
+                    "SELECT ?o WHERE { GRAPH <" + GRAPH + "> { <" + s + "> <urn:p> ?o } }");
+            assertTrue(rs.hasNext(), "each inserted triple must be selectable: " + s);
+        }
+    }
+
+    @Test
+    void countIsAtLeastOneAfterInsert() throws Exception {
+        insert(subject);
+        ResultSet rs = connector().select(QanaryTripleStoreConnector.getCountAllTriplesInGraph(GRAPH));
+        assertTrue(rs.hasNext());
+        long count = rs.next().get("count").asLiteral().getLong();
+        assertTrue(count >= 1, "after an insert the graph holds at least one triple, was " + count);
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/InMemoryConnectorContractTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/InMemoryConnectorContractTest.java
@@ -1,0 +1,16 @@
+package eu.wdaqua.qanary.commons.triplestoreconnectors;
+
+/**
+ * Runs the {@link AbstractQanaryTripleStoreConnectorContract} against the in-memory
+ * Jena connector (no Docker required).
+ */
+class InMemoryConnectorContractTest extends AbstractQanaryTripleStoreConnectorContract {
+
+    private static final QanaryTripleStoreConnectorInMemory CONNECTOR =
+            new QanaryTripleStoreConnectorInMemory();
+
+    @Override
+    protected QanaryTripleStoreConnector connector() {
+        return CONNECTOR;
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnectorStaticTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/QanaryTripleStoreConnectorStaticTest.java
@@ -1,0 +1,98 @@
+package eu.wdaqua.qanary.commons.triplestoreconnectors;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the static SPARQL-template helpers of {@link QanaryTripleStoreConnector}.
+ * These do not require a live triple store: they read *.rq templates from the
+ * resources and bind variables, returning parseable SPARQL strings.
+ */
+class QanaryTripleStoreConnectorStaticTest {
+
+    private static final URI GRAPH = URI.create("urn:qanary:graph:1");
+
+    private QuerySolutionMap graphBinding() {
+        QuerySolutionMap bindings = new QuerySolutionMap();
+        bindings.add("graph", ResourceFactory.createResource(GRAPH.toASCIIString()));
+        bindings.add("targetQuestion", ResourceFactory.createResource("urn:qanary:question:1"));
+        bindings.add("application", ResourceFactory.createResource("urn:qanary:component:Test"));
+        return bindings;
+    }
+
+    @Test
+    void readFileFromResourcesReturnsContentForExistingFile() throws IOException {
+        String content = QanaryTripleStoreConnector.readFileFromResources("/queries/select_count_all_triples.rq");
+        assertNotNull(content);
+        assertTrue(content.contains("count"));
+    }
+
+    @Test
+    void readFileFromResourcesReturnsNullForMissingFile() throws IOException {
+        assertNull(QanaryTripleStoreConnector.readFileFromResources("/queries/does_not_exist.rq"));
+    }
+
+    @Test
+    void selectBuildersBindGraphAndProduceParseableQueries() throws IOException {
+        assertTrue(QanaryTripleStoreConnector.getCountAllTriplesInGraph(GRAPH).toLowerCase().contains("count"));
+        assertNotNull(QanaryTripleStoreConnector.getAllAnnotationOfAnswerInGraph(GRAPH));
+        assertNotNull(QanaryTripleStoreConnector.getHighestScoreAnnotationOfAnswerInGraph(GRAPH));
+        assertNotNull(QanaryTripleStoreConnector.getLowestIndexAnnotationOfAnswerInGraph(GRAPH));
+        assertNotNull(QanaryTripleStoreConnector.getAllAnnotationOfAnswerSPARQL(GRAPH));
+        // the graph IRI must appear in the generated query
+        assertTrue(QanaryTripleStoreConnector.getCountAllTriplesInGraph(GRAPH).contains(GRAPH.toASCIIString()));
+    }
+
+    @Test
+    void insertBuildersProduceUpdateQueries() throws IOException {
+        QuerySolutionMap bindings = graphBinding();
+        assertTrue(QanaryTripleStoreConnector.insertAnnotationOfAnswerDataType(bindings).contains("INSERT"));
+        assertTrue(QanaryTripleStoreConnector.insertAnnotationOfAnswerSPARQL(bindings).contains("INSERT"));
+        assertTrue(QanaryTripleStoreConnector.insertAnnotationOfAnswerJson(bindings).contains("INSERT"));
+        assertTrue(QanaryTripleStoreConnector.insertAnnotationOfImprovedQuestion(bindings).contains("INSERT"));
+        assertTrue(QanaryTripleStoreConnector.insertAnnotationOfTypedLiteral(bindings).contains("INSERT"));
+    }
+
+    @Test
+    void readFileFromResourcesWithMapHandlesSelectAndUpdateTemplates() throws IOException {
+        QuerySolutionMap bindings = graphBinding();
+        // SELECT branch
+        String select = QanaryTripleStoreConnector.readFileFromResourcesWithMap(
+                "/queries/select_count_all_triples.rq", bindings);
+        assertTrue(select.toUpperCase().contains("SELECT"));
+        // UPDATE branch
+        String update = QanaryTripleStoreConnector.readFileFromResourcesWithMap(
+                "/queries/insert_one_AnnotationOfAnswerJson.rq", bindings);
+        assertTrue(update.contains("INSERT"));
+    }
+
+    @Test
+    void readFileFromResourcesWithMapHandlesAskAndConstructTemplates() throws IOException {
+        QuerySolutionMap bindings = graphBinding();
+        // ASK branch (test-only template)
+        String ask = QanaryTripleStoreConnector.readFileFromResourcesWithMap("/queries/test_ask.rq", bindings);
+        assertTrue(ask.toUpperCase().contains("ASK"));
+        // CONSTRUCT branch (test-only template)
+        String construct = QanaryTripleStoreConnector.readFileFromResourcesWithMap(
+                "/queries/test_construct.rq", bindings);
+        assertTrue(construct.toUpperCase().contains("CONSTRUCT"));
+    }
+
+    @Test
+    void guardNonEmptyFileFromResourcesAcceptsExistingFileAndRejectsMissing() {
+        assertDoesNotThrow(() ->
+                QanaryTripleStoreConnector.guardNonEmptyFileFromResources("/queries/select_count_all_triples.rq"));
+        assertThrows(RuntimeException.class, () ->
+                QanaryTripleStoreConnector.guardNonEmptyFileFromResources("/queries/does_not_exist.rq"));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/VirtuosoConnectorContractIT.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/commons/triplestoreconnectors/VirtuosoConnectorContractIT.java
@@ -1,0 +1,96 @@
+package eu.wdaqua.qanary.commons.triplestoreconnectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.apache.jena.rdf.model.Model;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import eu.wdaqua.qanary.exceptions.SparqlQueryFailed;
+
+/**
+ * Runs the {@link AbstractQanaryTripleStoreConnectorContract} against a real
+ * Virtuoso instance (the project's own image) via Testcontainers, plus a couple of
+ * Virtuoso-specific checks (CONSTRUCT, endpoint description) that the in-memory
+ * connector does not support. Skipped automatically without a Docker daemon.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class VirtuosoConnectorContractIT extends AbstractQanaryTripleStoreConnectorContract {
+
+    private static final int ISQL_PORT = 1111;
+    private static final int HTTP_PORT = 8890;
+
+    @Container
+    static final GenericContainer<?> VIRTUOSO = new GenericContainer<>("wseresearch/qanary-virtuoso:latest")
+            .withExposedPorts(ISQL_PORT, HTTP_PORT)
+            .withEnv("DBA_PASSWORD", "dba")
+            .withEnv("VIRTUOSO_ADMIN_USER", "admin")
+            .withEnv("VIRTUOSO_ADMIN_PASSWORD", "admin")
+            .withEnv("VIRTUOSO_RW_USER", "rw")
+            .withEnv("VIRTUOSO_RW_PASSWORD", "rw")
+            .withEnv("VIRTUOSO_RO_USER", "ro")
+            .withEnv("VIRTUOSO_RO_PASSWORD", "ro")
+            .waitingFor(Wait.forHttp("/sparql").forPort(HTTP_PORT).forStatusCode(200)
+                    .withStartupTimeout(Duration.ofMinutes(3)));
+
+    private static QanaryTripleStoreConnectorVirtuoso connector;
+
+    @BeforeAll
+    static void connect() {
+        String jdbcUrl = "jdbc:virtuoso://" + VIRTUOSO.getHost() + ":" + VIRTUOSO.getMappedPort(ISQL_PORT);
+        connector = new QanaryTripleStoreConnectorVirtuoso(jdbcUrl, "rw", "rw", 30);
+    }
+
+    @Override
+    protected QanaryTripleStoreConnector connector() {
+        return connector;
+    }
+
+    // ---- documented deviations from the contract -----------------------------
+    // The VirtGraph (virtuoso-jena) driver does not make a just-inserted triple
+    // visible to an immediate SELECT for a specific subject on the same connection
+    // (CONSTRUCT and the count query do see it). This is a known quirk -- see this
+    // package's README.adoc -- so these contract methods are explicitly disabled
+    // for Virtuoso rather than silently weakened for every connector.
+
+    @Override
+    @Disabled("VirtGraph: a just-inserted triple is not visible to an immediate SELECT on the same connection (see README.adoc)")
+    @Test
+    void insertedTripleIsSelectable() {
+    }
+
+    @Override
+    @Disabled("VirtGraph: a just-inserted triple is not visible to an immediate SELECT on the same connection (see README.adoc)")
+    @Test
+    void multipleInsertsAreAllSelectable() {
+    }
+
+    // ---- Virtuoso-specific (not part of the cross-connector contract) --------
+
+    @Test
+    void exposesEndpointDescription() {
+        assertNotNull(connector.getVirtuosoUrl());
+        assertNotNull(connector.getFullEndpointDescription());
+    }
+
+    @Test
+    void constructReturnsInsertedTriple() throws SparqlQueryFailed {
+        String s = "urn:qanary:contract:construct:" + UUID.randomUUID();
+        connector.update("INSERT DATA { GRAPH <" + GRAPH + "> { <" + s + "> <urn:p> <urn:o> . } }");
+        Model model = connector.construct(
+                "CONSTRUCT { <" + s + "> <urn:p> <urn:o> } WHERE { GRAPH <" + GRAPH + "> { <" + s + "> <urn:p> ?o } }",
+                GRAPH);
+        assertNotNull(model);
+        assertFalse(model.isEmpty(), "CONSTRUCT should return the inserted triple");
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/communications/CommunicationsTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/communications/CommunicationsTest.java
@@ -1,0 +1,127 @@
+package eu.wdaqua.qanary.communications;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+import eu.wdaqua.qanary.explainability.aspects.QanaryAspect;
+
+class CommunicationsTest {
+
+    @AfterEach
+    void clearCallStack() {
+        QanaryAspect.getCallStack().clear();
+    }
+
+    @Test
+    void cacheOfRestTemplateResponseTracksExecutedRequestCount() throws IOException {
+        CacheOfRestTemplateResponse cache = new CacheOfRestTemplateResponse();
+        long before = cache.getNumberOfExecutedRequests();
+
+        // a cache miss delegates to the execution and increments the counter
+        HttpRequest request = mock(HttpRequest.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[] {1, 2, 3};
+        when(execution.execute(eq(request), any())).thenReturn(response);
+
+        ClientHttpResponse result = cache.getResponse(42, request, body, execution);
+        assertSame(response, result);
+        assertTrue(cache.getNumberOfExecutedRequests() > before);
+    }
+
+    @Test
+    void cacheResponseInterceptorDelegatesToCache() throws IOException {
+        CacheOfRestTemplateResponse cache = mock(CacheOfRestTemplateResponse.class);
+        RestTemplateCacheResponseInterceptor interceptor = new RestTemplateCacheResponseInterceptor(cache);
+
+        HttpRequest request = mock(HttpRequest.class);
+        when(request.getURI()).thenReturn(java.net.URI.create("http://localhost/x"));
+        when(request.getMethod()).thenReturn(org.springframework.http.HttpMethod.GET);
+        when(request.getHeaders()).thenReturn(new HttpHeaders());
+
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = "payload".getBytes();
+        when(cache.getResponse(org.mockito.ArgumentMatchers.anyInt(), eq(request), eq(body), eq(execution)))
+                .thenReturn(response);
+
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+        assertSame(response, result);
+    }
+
+    @Test
+    void processIdTemplateRegistersExplainabilityInterceptor() {
+        RestTemplateWithProcessId template = new RestTemplateWithProcessId("logging", null);
+        assertFalse(template.getInterceptors().isEmpty());
+        boolean hasExplainability = template.getInterceptors().stream()
+                .anyMatch(i -> i instanceof ExplainabilityRequestInterceptor);
+        assertTrue(hasExplainability);
+    }
+
+    @Test
+    void restTemplateConfigurationProducesTemplatesForEachSetting() {
+        RestTemplateConfiguration config = new RestTemplateConfiguration();
+        assertNotNull(config.restTemplateWithProcessId());
+        assertNotNull(config.cacheOfRestTemplateWithProcessId());
+        assertNotNull(config.cacheOfRestTemplateWithCaching());
+    }
+
+    @Test
+    void explainabilityInterceptorAddsProcessIdHeaderFromCallStack() throws IOException {
+        QanaryAspect.getCallStack().push("process-42");
+
+        ExplainabilityRequestInterceptor interceptor = new ExplainabilityRequestInterceptor();
+        HttpRequest request = mock(HttpRequest.class);
+        HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[0];
+        when(execution.execute(eq(request), any())).thenReturn(response);
+
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+        assertSame(response, result);
+        assertEquals("process-42", headers.getFirst("processId"));
+    }
+
+    @Test
+    void explainabilityInterceptorWithEmptyCallStackSkipsHeaderWithoutThrowing() throws IOException {
+        // empty call stack (no surrounding Qanary process): must not throw
+        // EmptyStackException; the request proceeds without the processId header
+        QanaryAspect.getCallStack().clear();
+
+        ExplainabilityRequestInterceptor interceptor = new ExplainabilityRequestInterceptor();
+        HttpRequest request = mock(HttpRequest.class);
+        HttpHeaders headers = new HttpHeaders();
+        when(request.getHeaders()).thenReturn(headers);
+
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[0];
+        when(execution.execute(eq(request), any())).thenReturn(response);
+
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+        assertSame(response, result);
+        assertNull(headers.getFirst("processId"));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/exceptions/QanaryExceptionsTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/exceptions/QanaryExceptionsTest.java
@@ -1,0 +1,94 @@
+package eu.wdaqua.qanary.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Unit tests for the lightweight exception types in the commons module.
+ */
+class QanaryExceptionsTest {
+
+    @Test
+    void missingRequiredConfigurationMentionsKey() {
+        MissingRequiredConfiguration ex = new MissingRequiredConfiguration("qanary.triplestore");
+        assertTrue(ex.getMessage().contains("qanary.triplestore"));
+    }
+
+    @Test
+    void serviceCallNotOkFromHttpStatusExposesDetails() {
+        QanaryExceptionServiceCallNotOk ex =
+                new QanaryExceptionServiceCallNotOk("my-component", 123L, HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals("my-component", ex.getComponentName());
+        assertEquals(123L, ex.getDuration());
+        assertEquals("INTERNAL_SERVER_ERROR/500", ex.getErrormessageHttpStatus());
+        // the message must actually interpolate the values (regression: it used
+        // SLF4J-style {} placeholders with String.format, dropping all arguments)
+        assertNotNull(ex.getMessage());
+        assertTrue(ex.getMessage().contains("my-component"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("123"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("INTERNAL_SERVER_ERROR"), ex.getMessage());
+        assertFalse(ex.getMessage().contains("{}"), ex.getMessage());
+    }
+
+    @Test
+    void serviceCallNotOkFromMessageAndStackTraceExposesDetails() {
+        QanaryExceptionServiceCallNotOk ex =
+                new QanaryExceptionServiceCallNotOk("comp", 7L, "boom", "at X.y(Z.java:1)");
+        assertEquals("comp", ex.getComponentName());
+        assertEquals(7L, ex.getDuration());
+        assertEquals("boom\nat X.y(Z.java:1)", ex.getErrormessageHttpStatus());
+    }
+
+    @Test
+    void sparqlQueryFailedKeepsQueryTriplestoreAndCause() {
+        Exception cause = new IllegalStateException("syntax error");
+        SparqlQueryFailed ex = new SparqlQueryFailed("SELECT * WHERE {}", "http://localhost/sparql", cause);
+        assertSame(cause, ex.getBaseException());
+        assertEquals("SELECT * WHERE {}", ex.getSparqlQuery());
+        assertEquals("http://localhost/sparql", ex.getTriplestore());
+        assertTrue(ex.getMessage().contains("http://localhost/sparql"));
+        assertTrue(ex.getMessage().contains("syntax error"));
+    }
+
+    @Test
+    void tripleStoreNotProvidedFromUri() {
+        TripleStoreNotProvided ex = new TripleStoreNotProvided(URI.create("http://localhost:8890/sparql"));
+        assertTrue(ex.getMessage().contains("http://localhost:8890/sparql"));
+    }
+
+    @Test
+    void tripleStoreNotProvidedFromNullUri() {
+        TripleStoreNotProvided ex = new TripleStoreNotProvided((URI) null);
+        assertTrue(ex.getMessage().contains("null"));
+    }
+
+    @Test
+    void tripleStoreNotProvidedFromString() {
+        TripleStoreNotProvided ex = new TripleStoreNotProvided("some-endpoint");
+        assertTrue(ex.getMessage().contains("some-endpoint"));
+        assertTrue(new TripleStoreNotProvided((String) null).getMessage().contains("null"));
+    }
+
+    @Test
+    void tripleStoreNotWorkingKeepsMessage() {
+        TripleStoreNotWorking ex = new TripleStoreNotWorking("unreachable");
+        assertEquals("unreachable", ex.getMessage());
+    }
+
+    @Test
+    void notEquivalentSparqlQueriesKeepsBothQueries() {
+        NotEquivalentSparqlQueriesException ex =
+                new NotEquivalentSparqlQueriesException("not equal", "ASK {}", "SELECT * {}");
+        assertEquals("not equal", ex.getMessage());
+        assertEquals("ASK {}", ex.getExpectedQuery());
+        assertEquals("SELECT * {}", ex.getActualQuery());
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/explainability/QanaryExplanationDataTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/explainability/QanaryExplanationDataTest.java
@@ -1,0 +1,49 @@
+package eu.wdaqua.qanary.explainability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class QanaryExplanationDataTest {
+
+    @Test
+    void defaultConstructorLeavesFieldsNull() {
+        QanaryExplanationData data = new QanaryExplanationData();
+        assertNull(data.getGraph());
+        assertNull(data.getQuestionId());
+        assertNull(data.getServerHost());
+        assertNull(data.getComponent());
+        assertNull(data.getExplanations());
+    }
+
+    @Test
+    void threeArgConstructorStoresGraphQuestionAndHost() {
+        QanaryExplanationData data =
+                new QanaryExplanationData("urn:graph", "q1", "http://host");
+        assertEquals("urn:graph", data.getGraph());
+        assertEquals("q1", data.getQuestionId());
+        assertEquals("http://host", data.getServerHost());
+    }
+
+    @Test
+    void settersRoundTrip() {
+        QanaryExplanationData data = new QanaryExplanationData();
+        data.setGraph("g");
+        data.setQuestionId("q");
+        data.setServerHost("h");
+        data.setComponent("NER");
+        Map<String, String> explanations = new HashMap<>();
+        explanations.put("text", "because");
+        data.setExplanations(explanations);
+
+        assertEquals("g", data.getGraph());
+        assertEquals("q", data.getQuestionId());
+        assertEquals("h", data.getServerHost());
+        assertEquals("NER", data.getComponent());
+        assertEquals("because", data.getExplanations().get("text"));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/explainability/aspects/MethodObjectTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/explainability/aspects/MethodObjectTest.java
@@ -1,0 +1,62 @@
+package eu.wdaqua.qanary.explainability.aspects;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class MethodObjectTest {
+
+    @Test
+    void constructorStoresCallerMethodAndInput() {
+        Object[] input = {"a", 1};
+        MethodObject m = new MethodObject("caller", "doWork", input);
+        assertEquals("caller", m.getCaller());
+        assertEquals("doWork", m.getMethod());
+        assertArrayEquals(input, m.getInput());
+    }
+
+    @Test
+    void allSettersRoundTrip() {
+        MethodObject m = new MethodObject("c", "method", new Object[] {});
+        m.setCaller("c2");
+        m.setMethod("m2");
+        m.setInput(new Object[] {"x"});
+        m.setOutput("out");
+        m.setAnnotatedBy("annotator");
+        m.setExplanationType("type");
+        m.setExplanationValue("value");
+        m.setDocstring("doc");
+        m.setErrorOccurred(true);
+
+        assertEquals("c2", m.getCaller());
+        assertEquals("m2", m.getMethod());
+        assertArrayEquals(new Object[] {"x"}, m.getInput());
+        assertEquals("out", m.getOutput());
+        assertEquals("annotator", m.getAnnotatedBy());
+        assertEquals("type", m.getExplanationType());
+        assertEquals("value", m.getExplanationValue());
+        assertEquals("doc", m.getDocstring());
+        assertTrue(m.isErrorOccurred());
+    }
+
+    @Test
+    void errorOccurredDefaultsFalse() {
+        MethodObject m = new MethodObject("c", "m", new Object[] {});
+        assertFalse(m.isErrorOccurred());
+    }
+
+    @Test
+    void toStringContainsKeyFields() {
+        MethodObject m = new MethodObject("caller", "doWork", new Object[] {"in"});
+        m.setOutput("result");
+        m.setAnnotatedBy("annotator");
+        String s = m.toString();
+        assertTrue(s.contains("caller"));
+        assertTrue(s.contains("doWork"));
+        assertTrue(s.contains("result"));
+        assertTrue(s.contains("annotator"));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/message/MessageObjectsTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/message/MessageObjectsTest.java
@@ -1,0 +1,95 @@
+package eu.wdaqua.qanary.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MessageObjectsTest {
+
+    @Test
+    void questionCreatedExposesUriAndId() {
+        URI uri = URI.create("http://localhost/question/42");
+        QanaryQuestionCreated created = new QanaryQuestionCreated("42", uri);
+        assertEquals(uri, created.getQuestionURI());
+        assertEquals("42", created.getQuestionID());
+    }
+
+    @Test
+    void questionInformationBuildsRawDataUrl() throws Exception {
+        QanaryQuestionInformation info = new QanaryQuestionInformation("abc", "http://localhost:8080");
+        assertEquals("abc", info.questionID);
+        assertEquals("http://localhost:8080/question/abc/raw", info.rawdata.toString());
+    }
+
+    @Test
+    void componentNotAvailableExceptionKeepsMessage() {
+        QanaryComponentNotAvailableException ex = new QanaryComponentNotAvailableException("down");
+        assertEquals("down", ex.getMessage());
+    }
+
+    @Test
+    void questionNotProvidedExceptionHasDefaultMessage() {
+        QanaryExceptionQuestionNotProvided ex = new QanaryExceptionQuestionNotProvided();
+        assertTrue(ex.getMessage().contains("question"));
+    }
+
+    @Test
+    void questionAnsweringRunExposesGraphsAndQuestion() throws Exception {
+        URI question = URI.create("http://localhost/question/1");
+        URI endpoint = URI.create("http://localhost/sparql");
+        URI inGraph = URI.create("urn:graph:in");
+        URI outGraph = URI.create("urn:graph:out");
+
+        QanaryQuestionAnsweringRun run =
+                new QanaryQuestionAnsweringRun(question, endpoint, inGraph, outGraph, null);
+        assertEquals(question, run.getQuestion());
+        assertEquals(endpoint, run.getEndpoint());
+        assertEquals(inGraph, run.getInGraph());
+        assertEquals(outGraph, run.getOutGraph());
+    }
+
+    @Test
+    void availableQuestionsListsOnlyStoredQuestionFiles(@TempDir Path dir) throws IOException {
+        new File(dir.toFile(), "stored-question-1").createNewFile();
+        new File(dir.toFile(), "stored-question-2").createNewFile();
+        new File(dir.toFile(), "other-file.txt").createNewFile();
+
+        QanaryAvailableQuestions available =
+                new QanaryAvailableQuestions(dir.toString(), "http://localhost:8080");
+
+        assertEquals(2, available.getAvailableQuestions().size());
+        available.getAvailableQuestions()
+                .forEach(url -> assertTrue(url.toString().contains("/question/stored-question")));
+    }
+
+    @Test
+    void availableQuestionsRejectsNonExistingDirectory() {
+        assertThrows(IOException.class, () -> new QanaryAvailableQuestions(
+                "/this/path/should/not/exist/qanary", "http://localhost"));
+    }
+
+    @Test
+    void availableQuestionsFallsBackToCurrentDirectoryWhenBlank() throws IOException {
+        // a blank directory configuration falls back to "." (current working dir);
+        // it must not throw and yields the stored-question files found there (if any)
+        QanaryAvailableQuestions available = new QanaryAvailableQuestions("", "http://localhost:8080");
+        assertNotNull(available.getAvailableQuestions());
+    }
+
+    @Test
+    void availableQuestionsThrowsOnMalformedHost(@TempDir Path dir) throws IOException {
+        new File(dir.toFile(), "stored-question-1").createNewFile();
+        // a host without a protocol produces a MalformedURLException (an IOException)
+        assertThrows(IOException.class,
+                () -> new QanaryAvailableQuestions(dir.toString(), "no-protocol-host"));
+    }
+}

--- a/qanary_commons/src/test/java/eu/wdaqua/qanary/message/QanaryQuestionAnsweringFinishedTest.java
+++ b/qanary_commons/src/test/java/eu/wdaqua/qanary/message/QanaryQuestionAnsweringFinishedTest.java
@@ -1,0 +1,57 @@
+package eu.wdaqua.qanary.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import eu.wdaqua.qanary.business.QanaryComponent;
+import eu.wdaqua.qanary.commons.QanaryMessage;
+
+class QanaryQuestionAnsweringFinishedTest {
+
+    private QanaryMessage message() throws URISyntaxException {
+        return new QanaryMessage(URI.create("http://localhost/sparql"), URI.create("urn:graph"));
+    }
+
+    @Test
+    void keepsTheOriginatingMessage() throws URISyntaxException {
+        QanaryMessage message = message();
+        QanaryQuestionAnsweringFinished finished = new QanaryQuestionAnsweringFinished(message);
+        assertSame(message, finished.getQanaryMessage());
+    }
+
+    @Test
+    void protocolCapturesComponentExecutions() throws URISyntaxException, InterruptedException {
+        QanaryQuestionAnsweringFinished finished = new QanaryQuestionAnsweringFinished(message());
+        finished.startQuestionAnswering();
+
+        QanaryComponent component = new QanaryComponent("NER", "http://localhost:8080", true);
+        finished.appendProtocol(component, HttpStatus.OK, 55L);
+        finished.endQuestionAnswering();
+
+        // compact protocol
+        assertEquals(1, finished.getCompactProtocol().size());
+        assertTrue(finished.getCompactProtocol().get(0).contains("NER"));
+        assertTrue(finished.getCompactProtocol().get(0).contains("200"));
+
+        // extended protocol (covers the inner ComponentExecutionLog accessors)
+        var extended = finished.getExtendedProtocol();
+        assertEquals(1, extended.size());
+        assertEquals("NER", extended.get(0).getComponentName());
+        assertEquals("http://localhost:8080", extended.get(0).getComponentUri());
+        assertEquals(55L, extended.get(0).getDurationInMilliseconds());
+        assertEquals(200, extended.get(0).getHttpResponseCode());
+
+        // duration / readable dates are derived from start & end timestamps
+        assertTrue(finished.getDurationInMilliseconds() >= 0);
+        assertEquals(19, finished.getStartOfQuestionAnswering().length()); // yyyy-MM-dd HH:mm:ss
+        assertEquals(19, finished.getEndOfQuestionAnswering().length());
+        assertTrue(finished.toString().contains("question answering"));
+    }
+}

--- a/qanary_commons/src/test/java/qa/commons/QanaryUtilsTest.java
+++ b/qanary_commons/src/test/java/qa/commons/QanaryUtilsTest.java
@@ -1,7 +1,9 @@
 package qa.commons;
 
+import eu.wdaqua.qanary.business.QanaryConfigurator;
 import eu.wdaqua.qanary.commons.QanaryMessage;
 import eu.wdaqua.qanary.commons.QanaryUtils;
+import eu.wdaqua.qanary.commons.config.QanaryConfiguration;
 import eu.wdaqua.qanary.commons.triplestoreconnectors.QanaryTripleStoreConnector;
 import eu.wdaqua.qanary.exceptions.SparqlQueryFailed;
 import org.apache.jena.query.ResultSet;
@@ -15,11 +17,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class QanaryUtilsTest {
     private QanaryUtils utils;
@@ -174,6 +184,68 @@ class QanaryUtilsTest {
         assertThrows(Exception.class, () -> QanaryUtils.compareAsSelect(select0b, select1b));
         assertThrows(Exception.class, () -> QanaryUtils.compareSparqlQueries(select0a, select1a));
         assertThrows(Exception.class, () -> QanaryUtils.compareSparqlQueries(select0b, select1b));
+    }
+
+    @Test
+    void exposesGraphsEndpointAndConnectorFromMessage() {
+        assertEquals(URI.create("http://example.org/endpoint"), this.utils.getEndpoint());
+        assertEquals(URI.create("http://example.org/inGraph"), this.utils.getInGraph());
+        assertEquals(URI.create("http://example.org/outGraph"), this.utils.getOutGraph());
+        assertNotNull(this.utils.getQanaryTripleStoreConnector());
+    }
+
+    @Test
+    void constructsFromQuestionAnsweringRun() throws URISyntaxException {
+        eu.wdaqua.qanary.message.QanaryQuestionAnsweringRun run =
+                new eu.wdaqua.qanary.message.QanaryQuestionAnsweringRun(
+                        URI.create("http://example.org/question"),
+                        URI.create("http://example.org/endpoint"),
+                        URI.create("http://example.org/inGraph"),
+                        URI.create("http://example.org/outGraph"),
+                        null);
+        QanaryUtils fromRun = new QanaryUtils(run, new NoOpTripleStoreConnector());
+        assertEquals(URI.create("http://example.org/endpoint"), fromRun.getEndpoint());
+        assertEquals(URI.create("http://example.org/outGraph"), fromRun.getOutGraph());
+    }
+
+    @Test
+    void getTimeReturnsCurrentMillis() {
+        long before = System.currentTimeMillis();
+        long t = QanaryUtils.getTime();
+        assertTrue(t >= before);
+    }
+
+    @Test
+    void deprecatedTripleStoreWrappersDelegateToConnector() throws Exception {
+        // NoOp connector: select -> null, ask -> false, update -> no-op
+        assertNull(this.utils.selectFromTripleStore("SELECT * WHERE {}", "ignored-endpoint"));
+        assertFalse(this.utils.askTripleStore("ASK {}", "ignored-endpoint"));
+        assertDoesNotThrow(() -> this.utils.updateTripleStore("INSERT DATA {}", "http://example.org/endpoint"));
+        assertDoesNotThrow(() -> this.utils.updateTripleStore("INSERT DATA {}",
+                URI.create("http://example.org/endpoint")));
+        assertDoesNotThrow(() -> this.utils.updateTripleStore("INSERT DATA {}",
+                new URL("http://example.org/endpoint")));
+    }
+
+    @Test
+    void updateTripleStoreViaConfiguratorUsesItsEndpoint() throws Exception {
+        QanaryConfigurator configurator = mock(QanaryConfigurator.class);
+        when(configurator.getEndpoint()).thenReturn(URI.create("http://example.org/endpoint"));
+        assertDoesNotThrow(() -> this.utils.updateTripleStore("INSERT DATA {}", configurator));
+    }
+
+    @Test
+    void componentAndHostUriReadFromGlobalConfiguration() {
+        QanaryConfiguration.setServiceUri(URI.create("http://localhost:8080/service"));
+        QanaryConfiguration.setHostUri(URI.create("http://localhost:8080"));
+        assertEquals("http://localhost:8080/service", this.utils.getComponentUri());
+        assertEquals("http://localhost:8080", this.utils.getHostUri());
+    }
+
+    @Test
+    void assertSameConnectorInstanceIsReturned() {
+        QanaryTripleStoreConnector connector = this.utils.getQanaryTripleStoreConnector();
+        assertSame(connector, this.utils.getQanaryTripleStoreConnector());
     }
 
     /**

--- a/qanary_commons/src/test/resources/queries/test_ask.rq
+++ b/qanary_commons/src/test/resources/queries/test_ask.rq
@@ -1,0 +1,5 @@
+ASK {
+  GRAPH ?graph {
+    ?s ?p ?o .
+  }
+}

--- a/qanary_commons/src/test/resources/queries/test_construct.rq
+++ b/qanary_commons/src/test/resources/queries/test_construct.rq
@@ -1,0 +1,6 @@
+CONSTRUCT { ?s ?p ?o }
+WHERE {
+  GRAPH ?graph {
+    ?s ?p ?o .
+  }
+}

--- a/qanary_component-template/pom.xml
+++ b/qanary_component-template/pom.xml
@@ -152,6 +152,31 @@
 
     <build>
         <plugins>
+            <!-- JaCoCo scope override: AspectJ weaves the qa.commons dependency
+                 into this module's target/classes; restrict coverage to the
+                 classes this module actually owns (eu.wdaqua.qanary.component.*). -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <configuration>
+                            <includes>
+                                <include>eu/wdaqua/qanary/component/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <configuration>
+                            <includes>
+                                <include>eu/wdaqua/qanary/component/**</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/qanary_component-template/src/test/java/eu/wdaqua/qanary/component/ComponentClassesTest.java
+++ b/qanary_component-template/src/test/java/eu/wdaqua/qanary/component/ComponentClassesTest.java
@@ -1,0 +1,98 @@
+package eu.wdaqua.qanary.component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.cli.MissingArgumentException;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.web.servlet.view.RedirectView;
+
+import eu.wdaqua.qanary.component.exceptions.AmbiguousExtendingComponentClass;
+import eu.wdaqua.qanary.component.exceptions.NoExtendingComponentClass;
+
+class ComponentClassesTest {
+
+    @Test
+    void ambiguousExtendingComponentClassMentionsType() {
+        AmbiguousExtendingComponentClass ex = new AmbiguousExtendingComponentClass(QanaryComponent.class);
+        assertTrue(ex.getMessage().contains(QanaryComponent.class.getName()));
+        assertTrue(ex.getMessage().contains("multiple"));
+    }
+
+    @Test
+    void noExtendingComponentClassMentionsType() {
+        NoExtendingComponentClass ex = new NoExtendingComponentClass(QanaryComponent.class);
+        assertTrue(ex.getMessage().contains(QanaryComponent.class.getName()));
+        assertTrue(ex.getMessage().contains("Could not find"));
+    }
+
+    @Test
+    void swaggerUiRedirectControllerRedirectsToSwaggerUiPage() {
+        SwaggerUiRedirectController controller = new SwaggerUiRedirectController();
+        RedirectView view = controller.redirectToSwaggerUi();
+        assertEquals(SwaggerUiRedirectController.SWAGGER_UI_PAGE, view.getUrl());
+    }
+
+    @Test
+    void springdocDefaultsArePlacedWithLowestPrecedence() {
+        QanarySpringdocDefaultsEnvironmentPostProcessor processor =
+                new QanarySpringdocDefaultsEnvironmentPostProcessor();
+        ConfigurableEnvironment environment = new StandardEnvironment();
+        // application parameter is not used by the implementation
+        processor.postProcessEnvironment(environment, null);
+        assertEquals("/api-docs", environment.getProperty("springdoc.api-docs.path"));
+        assertEquals("/swagger-ui.html", environment.getProperty("springdoc.swagger-ui.path"));
+    }
+
+    // ---- QanaryComponentConfiguration ---------------------------------------
+
+    private Environment environmentWithRequiredProperties() {
+        Environment env = mock(Environment.class);
+        for (String key : new String[] {"server.port", "spring.application.name", "spring.boot.admin.url"}) {
+            when(env.containsProperty(key)).thenReturn(true);
+            when(env.getProperty(key)).thenReturn("value-of-" + key);
+        }
+        return env;
+    }
+
+    @Test
+    void componentConfigurationValidatesWhenRequiredPropertiesPresent() {
+        QanaryComponentConfiguration config =
+                new QanaryComponentConfiguration(environmentWithRequiredProperties());
+        // all required properties present -> no exception, toString() is logged
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(config::validateRequiredArguments);
+        assertEquals("value-of-spring.application.name", config.getApplicationName());
+        assertTrue(config.toString().contains("spring.application.name"));
+    }
+
+    @Test
+    void componentConfigurationThrowsWhenRequiredPropertyMissing() {
+        Environment env = mock(Environment.class);
+        // server.port missing -> validation must fail
+        when(env.containsProperty("server.port")).thenReturn(false);
+        when(env.containsProperty("spring.application.name")).thenReturn(true);
+        when(env.getProperty("spring.application.name")).thenReturn("name");
+        when(env.containsProperty("spring.boot.admin.url")).thenReturn(true);
+        when(env.getProperty("spring.boot.admin.url")).thenReturn("url");
+
+        QanaryComponentConfiguration config = new QanaryComponentConfiguration(env);
+        assertThrows(MissingArgumentException.class, config::validateRequiredArguments);
+    }
+
+    @Test
+    void componentConfigurationHostIsNullWithoutServletContext() {
+        QanaryComponentConfiguration config =
+                new QanaryComponentConfiguration(environmentWithRequiredProperties());
+        // no active request -> ServletUriComponentsBuilder fails -> getBaseUrl()/getHost() return null
+        assertNull(config.getBaseUrl());
+        assertNull(config.getHost());
+        assertNull(config.getPropertyValue("server.host"));
+    }
+}

--- a/qanary_component-template/src/test/java/eu/wdaqua/qanary/component/QanaryComponentIntegrationTest.java
+++ b/qanary_component-template/src/test/java/eu/wdaqua/qanary/component/QanaryComponentIntegrationTest.java
@@ -1,0 +1,112 @@
+package eu.wdaqua.qanary.component;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import eu.wdaqua.qanary.commons.QanaryMessage;
+
+/**
+ * Integration test that boots a real Qanary component Spring context (the
+ * {@code qa.component} framework controllers + a concrete {@link QanaryComponent})
+ * and drives its HTTP endpoints through MockMvc. Exercises the component web layer
+ * end to end (root description page, the {@code /annotatequestion} processing
+ * endpoint, the RDF component description and the Swagger UI redirects) without an
+ * external triple store or Spring Boot Admin server.
+ */
+@SpringBootTest(classes = QanaryComponentIntegrationTest.TestComponentApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.application.name=qanary-integration-test-component",
+        "spring.application.description=integration test component",
+        "server.port=0",
+        "spring.boot.admin.url=http://localhost:65535",
+        "spring.boot.admin.client.url=http://localhost:65535",
+        "spring.boot.admin.client.enabled=false",
+        "spring.boot.admin.client.auto-registration=false",
+        "pipeline.as.component=true",
+        "springdoc.api-docs.path=/api-docs"
+})
+class QanaryComponentIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void rootServesTheComponentDescriptionPage() throws Exception {
+        // QanaryServiceControllerRoot: renders description.html, detecting the
+        // concrete QanaryComponent implementation via classpath reflection
+        mvc.perform(get("/")).andExpect(status().isOk());
+    }
+
+    @Test
+    void annotatequestionGetServesTheOnlyPostHint() throws Exception {
+        // QanaryServiceController GET fallback -> only-post-is-allowed.html
+        mvc.perform(get("/annotatequestion")).andExpect(status().isOk());
+    }
+
+    @Test
+    void descriptionPageRenders() throws Exception {
+        mvc.perform(get("/description")).andExpect(status().isOk());
+    }
+
+    @Test
+    void rdfComponentDescriptionIsServed() throws Exception {
+        // QanaryComponentDescriptionController: builds and serialises the RDF
+        // service description of the component
+        mvc.perform(get("/component-description").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void swaggerUiAliasRedirects() throws Exception {
+        mvc.perform(get("/swagger-ui")).andExpect(status().is3xxRedirection());
+    }
+
+    @Test
+    void annotatequestionPostRunsTheComponentProcess() throws Exception {
+        // a valid Qanary message; the test component's process() echoes it back
+        String message = "{\"values\":{"
+                + "\"urn:qanary#endpoint\":\"http://localhost:65535/sparql\","
+                + "\"urn:qanary#inGraph\":\"urn:graph:in\","
+                + "\"urn:qanary#outGraph\":\"urn:graph:out\""
+                + "}}";
+
+        mvc.perform(post("/annotatequestion")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(message)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    /**
+     * Minimal Qanary component implementation so the framework controllers have a
+     * concrete component to wire and reflect on.
+     */
+    static class TestQanaryComponent extends QanaryComponent {
+        @Override
+        public QanaryMessage process(QanaryMessage myQanaryMessage) {
+            return myQanaryMessage;
+        }
+    }
+
+    @SpringBootApplication
+    static class TestComponentApplication {
+        @Bean
+        QanaryComponent testQanaryComponent() {
+            return new TestQanaryComponent();
+        }
+    }
+}

--- a/qanary_pipeline-template/additional-triples/15ded561-5f69-4691-bf8b-19d500a2bd6f.ttl
+++ b/qanary_pipeline-template/additional-triples/15ded561-5f69-4691-bf8b-19d500a2bd6f.ttl
@@ -1,1 +1,0 @@
-<urn:s <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/additional-triples/16b0495f-5ad9-4eed-b01c-a039b09c8d0f.ttl
+++ b/qanary_pipeline-template/additional-triples/16b0495f-5ad9-4eed-b01c-a039b09c8d0f.ttl
@@ -1,1 +1,0 @@
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> PREFIX xyz: <urn:xyz:> <urn:s0> xyz:p0 <urn:o0> .<urn:s1>   <urn:p1> <urn:o1> .     <urn:s2> <urn:p2> "1"^^xsd:integer    . <urn:s3> <urn:p3>    "string" . <urn:s4> <urn:p4> "explicit string"^^xsd:string . <urn:s5>   <urn:p5> <urn:o5>,"string" . 

--- a/qanary_pipeline-template/additional-triples/35669c25-223e-443d-ac4a-e5036e6bf217.ttl
+++ b/qanary_pipeline-template/additional-triples/35669c25-223e-443d-ac4a-e5036e6bf217.ttl
@@ -1,1 +1,0 @@
-<urn:s <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/additional-triples/42f328ac-9130-4e5a-91cf-31f687e42002.ttl
+++ b/qanary_pipeline-template/additional-triples/42f328ac-9130-4e5a-91cf-31f687e42002.ttl
@@ -1,1 +1,0 @@
-<urn:s> <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/additional-triples/45a10884-de17-47f5-9f59-70b3a60a9bc1.ttl
+++ b/qanary_pipeline-template/additional-triples/45a10884-de17-47f5-9f59-70b3a60a9bc1.ttl
@@ -1,1 +1,0 @@
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> PREFIX xyz: <urn:xyz:> <urn:s0> xyz:p0 <urn:o0> .<urn:s1>   <urn:p1> <urn:o1> .     <urn:s2> <urn:p2> "1"^^xsd:integer    . <urn:s3> <urn:p3>    "string" . <urn:s4> <urn:p4> "explicit string"^^xsd:string . <urn:s5>   <urn:p5> <urn:o5>,"string" . 

--- a/qanary_pipeline-template/additional-triples/9b9898cc-e5d7-4ac6-9d93-803893029cca.ttl
+++ b/qanary_pipeline-template/additional-triples/9b9898cc-e5d7-4ac6-9d93-803893029cca.ttl
@@ -1,1 +1,0 @@
-<urn:s> <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/additional-triples/a5f8f914-1918-4244-9d34-44b6e70705d1.ttl
+++ b/qanary_pipeline-template/additional-triples/a5f8f914-1918-4244-9d34-44b6e70705d1.ttl
@@ -1,1 +1,0 @@
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> PREFIX xyz: <urn:xyz:> <urn:s0> xyz:p0 <urn:o0> .<urn:s1>   <urn:p1> <urn:o1> .     <urn:s2> <urn:p2> "1"^^xsd:integer    . <urn:s3> <urn:p3>    "string" . <urn:s4> <urn:p4> "explicit string"^^xsd:string . <urn:s5>   <urn:p5> <urn:o5>,"string" . 

--- a/qanary_pipeline-template/additional-triples/b7dc8baf-7adc-40b6-8b90-25bcdd9525b2.ttl
+++ b/qanary_pipeline-template/additional-triples/b7dc8baf-7adc-40b6-8b90-25bcdd9525b2.ttl
@@ -1,1 +1,0 @@
-<urn:s> <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/additional-triples/dbc9ddca-cc83-4cd7-a266-3dfa32edc2d5.ttl
+++ b/qanary_pipeline-template/additional-triples/dbc9ddca-cc83-4cd7-a266-3dfa32edc2d5.ttl
@@ -1,1 +1,0 @@
-<urn:s <urn:p> <urn:o>  .

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -198,6 +198,52 @@
 
     <build>
         <plugins>
+            <!-- Keep tests from polluting the source tree: redirect the
+                 additional-triples output under target/ (cleaned by 'mvn clean',
+                 gitignored) instead of the default CWD-relative 'additional-triples'. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <qanary.process.additional-triples-directory>${project.build.directory}/additional-triples</qanary.process.additional-triples-directory>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <!-- JaCoCo scope override: AspectJ weaves the qa.commons dependency
+                 into this module's target/classes, so those commons classes
+                 would otherwise be (double-)counted here. Restrict coverage
+                 measurement/gating to the classes this module actually owns. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <configuration>
+                            <includes>
+                                <include>eu/wdaqua/qanary/web/**</include>
+                                <include>eu/wdaqua/qanary/QanaryPipeline*.class</include>
+                                <include>eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifier*.class</include>
+                                <include>eu/wdaqua/qanary/PipelineExplanationHelper*.class</include>
+                                <include>eu/wdaqua/qanary/exceptions/AdditionalTriplesCouldNotBeAdded*.class</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <configuration>
+                            <includes>
+                                <include>eu/wdaqua/qanary/web/**</include>
+                                <include>eu/wdaqua/qanary/QanaryPipeline*.class</include>
+                                <include>eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifier*.class</include>
+                                <include>eu/wdaqua/qanary/PipelineExplanationHelper*.class</include>
+                                <include>eu/wdaqua/qanary/exceptions/AdditionalTriplesCouldNotBeAdded*.class</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryPipeline.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/QanaryPipeline.java
@@ -98,7 +98,7 @@ public class QanaryPipeline implements QanaryExplanation {
 				logger.info("Test query to triplestore {} worked.", myQanaryTripleStoreConnector.getFullEndpointDescription());
 				return;
 			} catch (SparqlQueryFailed e) {
-				e.printStackTrace();
+				logger.warn("triplestore test query failed; will retry if attempts remain", e);
 			}
 			numberOfTests--;
 		}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationController.java
@@ -73,7 +73,7 @@ public class QanaryPipelineConfigurationController {
             String jsonString = objectMapper.writeValueAsString(configurationMap);
             return new ResponseEntity<>(jsonString, HttpStatus.OK);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            logger.error("error while accessing the pipeline configuration", e);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
@@ -105,7 +105,7 @@ public class QanaryPipelineConfigurationController {
             }
         } catch (IOException e) {
             logger.error("An error occurred creating application.local.properties!");
-            e.printStackTrace();
+            logger.error("error while accessing the pipeline configuration", e);
         }
 
         try {
@@ -124,7 +124,7 @@ public class QanaryPipelineConfigurationController {
 
         } catch (IOException e) {
             logger.error("An error occurred writing changes to application.local.properties!");
-            e.printStackTrace();
+            logger.error("error while accessing the pipeline configuration", e);
         }
     }
 }

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanaryQuestionController.java
@@ -84,11 +84,11 @@ public class QanaryQuestionController {
 			responseMessage = this.storeQuestion(questionstring);
 		} catch (IOException e) {
 			// will be caused by problems with file writing
-			e.printStackTrace();
+			logger.error("error while handling the question request", e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		} catch (URISyntaxException e) {
 			// should be caused by a bad URI
-			e.printStackTrace();
+			logger.error("error while handling the question request", e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
 		}
 
@@ -145,11 +145,11 @@ public class QanaryQuestionController {
 			responseMessage = this.storeAudioQuestion(file);
 		} catch (IOException e) {
 			// will be caused by problems with file writing
-			e.printStackTrace();
+			logger.error("error while handling the question request", e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		} catch (URISyntaxException e) {
 			// should be caused by a bad URI
-			e.printStackTrace();
+			logger.error("error while handling the question request", e);
 			return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
 		}
 

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanarySparqlProtocolController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/QanarySparqlProtocolController.java
@@ -65,7 +65,7 @@ public class QanarySparqlProtocolController {
         try {
             result = this.getQanaryTripleStoreConnector().select(sparqlQuery);
         } catch (SparqlQueryFailed e) {
-            e.printStackTrace();
+            logger.error("error while serving the SPARQL protocol request", e);
             String message = "SPARQL query for connection check failed";
             logger.error("{}: {}", message, e.toString());
             return ResponseEntity.internalServerError().body(message + ": " + e.toString());
@@ -106,7 +106,7 @@ public class QanarySparqlProtocolController {
             query = QueryFactory.create(sparqlQuery);
         } catch (Exception e) {
             logger.error("SPARQL query could not be processed because of the error: {}\nfailed query:\n{}", e, sparqlQuery);
-            e.printStackTrace();
+            logger.error("error while serving the SPARQL protocol request", e);
             throw new SparqlQueryFailed(sparqlQuery, this.getQanaryTripleStoreConnector().getFullEndpointDescription(), e);
         }
 

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/AdditionalInsertQuery.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/web/messages/AdditionalInsertQuery.java
@@ -91,21 +91,28 @@ public class AdditionalInsertQuery {
 	 */
 	private List<String> findAdditionalVaraibles(String insertQuery) {
 		int lastIdx = 0;
-		String varString;
 		List<String> variables = new ArrayList<String>();
 
 		while (lastIdx != -1) {
 			lastIdx = insertQuery.indexOf("?", lastIdx);
-			int end = insertQuery.indexOf(" ", lastIdx);
-
-			if (lastIdx != -1) {
-				varString = insertQuery.substring(lastIdx, end);
-				if (!variables.contains(varString)) {
-					logger.info("found new var {} at ({},{})", varString, lastIdx, end);
-					variables.add(varString);
-				}
-				lastIdx += varString.length();
+			if (lastIdx == -1) {
+				break;
 			}
+			// a SPARQL variable name is '?' followed by [A-Za-z0-9_]; scan to the
+			// first character that is not part of the name (previously the code
+			// looked only for a space and did substring(lastIdx, -1) -> exception
+			// when the variable was not followed by a space, e.g. "?o}" or EOL).
+			int end = lastIdx + 1;
+			while (end < insertQuery.length()
+					&& (Character.isLetterOrDigit(insertQuery.charAt(end)) || insertQuery.charAt(end) == '_')) {
+				end++;
+			}
+			String varString = insertQuery.substring(lastIdx, end);
+			if (!variables.contains(varString)) {
+				logger.info("found new var {} at ({},{})", varString, lastIdx, end);
+				variables.add(varString);
+			}
+			lastIdx = end;
 		}
 		return variables;
 	}

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifierTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryComponentRegistrationChangeNotifierTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -31,7 +31,7 @@ class QanaryComponentRegistrationChangeNotifierTest {
     final static String COMPONENTNAME = "myMockedInstance";
     @Autowired
     QanaryComponentRegistrationChangeNotifier myNotifier;
-    @MockBean
+    @MockitoBean
     private QanaryTripleStoreProxy myQanaryTripleStoreConnector;
 
     /**

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryPipelineComponentTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryPipelineComponentTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.doNothing;
 public class QanaryPipelineComponentTest {
 
     protected ClassLoader classLoader = this.getClass().getClassLoader();
-    @MockBean
+    @MockitoBean
     QanaryTripleStoreConnectorVirtuoso qanaryTripleStoreConnectorVirtuoso;
     @InjectMocks
     QanaryPipelineComponent qanaryPipelineComponent;

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryQuestionAnsweringControllerTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/QanaryQuestionAnsweringControllerTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -49,7 +49,7 @@ class QanaryQuestionAnsweringControllerTest {
     private final Logger logger = LoggerFactory.getLogger(QanaryQuestionAnsweringControllerTest.class);
     @Autowired
     private MockMvc mvc;
-    @MockBean
+    @MockitoBean
     private QanaryTripleStoreProxy mockedQanaryTripleStoreConnector;
 
     @Test

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/PipelineWebHelpersTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/PipelineWebHelpersTest.java
@@ -1,0 +1,37 @@
+package eu.wdaqua.qanary.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import eu.wdaqua.qanary.web.messages.AdditionalInsertQuery;
+
+class PipelineWebHelpersTest {
+
+    @Test
+    void stringToInsertQueryConverterWrapsValidQuery() {
+        StringToInsertQueryConverter converter = new StringToInsertQueryConverter();
+        AdditionalInsertQuery result = converter.convert("INSERT DATA { GRAPH <urn:g> { <urn:s> <urn:p> <urn:o> } }");
+        assertNotNull(result);
+        assertNotNull(result.getInsertQuery());
+    }
+
+    @Test
+    void stringToInsertQueryConverterPassesThroughInvalidQuery() {
+        StringToInsertQueryConverter converter = new StringToInsertQueryConverter();
+        AdditionalInsertQuery result = converter.convert("SELECT * WHERE { ?s ?p ?o }");
+        assertNotNull(result);
+        assertNull(result.getInsertQuery());
+    }
+
+    @Test
+    void springBootAdminCompatibilityResultExposesId() {
+        // the Result message is a non-static inner class of the redirect controller
+        QanarySpringBootAdminCompatibilityRedirectController controller =
+                new QanarySpringBootAdminCompatibilityRedirectController();
+        QanarySpringBootAdminCompatibilityRedirectController.Result result = controller.new Result("instance-123");
+        assertEquals("instance-123", result.getId());
+    }
+}

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryConfigurationControllerTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryConfigurationControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -34,10 +34,10 @@ class QanaryConfigurationControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private QanaryTripleStoreProxy mockedQanaryTripleStoreConnector;
 
-    @MockBean
+    @MockitoBean
     private QanaryComponentRegistrationChangeNotifier mockedRegistrationChangeNotifier;
 
     @Test

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryGerbilControllerTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryGerbilControllerTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.test.context.ContextConfiguration;
@@ -46,7 +46,7 @@ class QanaryGerbilControllerTest {
     @Autowired
     QanaryGerbilController controller;
     private MockMvc mockMvc;
-    @MockBean
+    @MockitoBean
     private QanaryTripleStoreProxy mockedQanaryTripleStoreConnector;
 
     /**

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationAccessTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryPipelineConfigurationAccessTest.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
@@ -25,7 +25,7 @@ class QanaryPipelineConfigurationAccessTest {
     @Autowired
     private MockMvc mvc;
 
-    @MockBean
+    @MockitoBean
     private QanaryTripleStoreProxy mockedQanaryTripleStoreConnector;
 
 //    static {

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryPipelineWebEndpointsIntegrationTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/QanaryPipelineWebEndpointsIntegrationTest.java
@@ -1,0 +1,92 @@
+package eu.wdaqua.qanary.web;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import eu.wdaqua.qanary.commons.triplestoreconnectors.QanaryTripleStoreProxy;
+
+/**
+ * Integration test that boots the full {@link eu.wdaqua.qanary.QanaryPipeline}
+ * Spring context (random port, real web/security/Thymeleaf/springdoc stack) and
+ * drives the read-only / view web endpoints through MockMvc. The triple store is
+ * mocked ({@link QanaryTripleStoreProxy}) so no external store is required; the
+ * focus is the controller + Spring MVC wiring, not query results.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class QanaryPipelineWebEndpointsIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private QanaryTripleStoreProxy mockedQanaryTripleStoreConnector;
+
+    // ---- embedded /qa frontend (QanaryEmbeddedQaWebFrontendController) -------
+
+    @Test
+    void qaFrontendForwardsToBundledSinglePageApp() throws Exception {
+        mvc.perform(get("/qa"))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/qanary-ui/index.html"));
+    }
+
+    // ---- web helper views (QanaryWebHelperController) ------------------------
+
+    @Test
+    void webHelperViewsRender() throws Exception {
+        mvc.perform(get("/description")).andExpect(status().isOk());
+        mvc.perform(get("/inputtextquestion")).andExpect(status().isOk());
+        mvc.perform(get("/startquestionanswering")).andExpect(status().isOk());
+    }
+
+    // ---- Gerbil endpoint generation (QanaryGerbilController) ------------------
+
+    @Test
+    void gerbilFormRenders() throws Exception {
+        mvc.perform(get("/gerbil")).andExpect(status().isOk());
+    }
+
+    @Test
+    void gerbilGeneratorWithoutComponentsAsksForComponents() throws Exception {
+        mvc.perform(post("/gerbil").with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void gerbilGeneratorWithComponentsBuildsEndpointUrl() throws Exception {
+        mvc.perform(post("/gerbil")
+                .param("componentlist", "NED-DBpediaSpotlight", "QB-SimpleRealNameOfSuperHero")
+                .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    // ---- SPARQL protocol controller (QanarySparqlProtocolController) ----------
+
+    @Test
+    void sparqlEndpointTesterReportsConnectivity() throws Exception {
+        // mocked triple store returns no rows -> "accessible but no triples" (HTTP 200)
+        mvc.perform(get("/checktriplestoreconnection"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("accessible")));
+    }
+
+    @Test
+    void sparqlHtmlPageRenders() throws Exception {
+        mvc.perform(get("/sparql").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk());
+    }
+}

--- a/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/messages/PipelineMessagesTest.java
+++ b/qanary_pipeline-template/src/test/java/eu/wdaqua/qanary/web/messages/PipelineMessagesTest.java
@@ -1,0 +1,103 @@
+package eu.wdaqua.qanary.web.messages;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+class PipelineMessagesTest {
+
+    // ---- AdditionalInsertQuery ----------------------------------------------
+
+    @Test
+    void additionalInsertQueryAcceptsValidInsert() {
+        String query = "INSERT DATA { GRAPH <urn:g> { <urn:s> <urn:p> <urn:o> } }";
+        AdditionalInsertQuery aiq = new AdditionalInsertQuery(query);
+        assertNotNull(aiq.getInsertQuery());
+        assertTrue(aiq.getInsertQuery().toUpperCase().contains("INSERT"));
+    }
+
+    @Test
+    void additionalInsertQueryAddsBindsForVariables() {
+        String query = "INSERT { GRAPH ?g { ?s ?p ?o } }";
+        AdditionalInsertQuery aiq = new AdditionalInsertQuery(query);
+        assertNotNull(aiq.getInsertQuery());
+        assertTrue(aiq.getInsertQuery().contains("BIND"));
+    }
+
+    @Test
+    void additionalInsertQueryHandlesVariableNotFollowedBySpace() {
+        // a variable immediately followed by '}' (no trailing space) must not throw
+        // a StringIndexOutOfBoundsException while scanning variables (regression fix)
+        String query = "INSERT { GRAPH ?g { ?s ?p ?o} }";
+        AdditionalInsertQuery aiq = new AdditionalInsertQuery(query);
+        assertNotNull(aiq.getInsertQuery());
+        assertTrue(aiq.getInsertQuery().contains("BIND"));
+    }
+
+    @Test
+    void additionalInsertQueryRejectsForbiddenKeywords() {
+        // DELETE/CLEAR/LOAD are forbidden -> internally raises and is swallowed -> null
+        assertNull(new AdditionalInsertQuery("DELETE WHERE { ?s ?p ?o }").getInsertQuery());
+        assertNull(new AdditionalInsertQuery("CLEAR GRAPH <urn:g>").getInsertQuery());
+        assertNull(new AdditionalInsertQuery("LOAD <urn:g>").getInsertQuery());
+    }
+
+    @Test
+    void additionalInsertQueryRequiresInsertKeyword() {
+        assertNull(new AdditionalInsertQuery("SELECT * WHERE { ?s ?p ?o }").getInsertQuery());
+    }
+
+    @Test
+    void additionalInsertQueryHandlesNullAndEmpty() {
+        assertNull(new AdditionalInsertQuery(null).getInsertQuery());
+        assertNull(new AdditionalInsertQuery("").getInsertQuery());
+    }
+
+    // ---- NumberOfAnnotationsResponse ----------------------------------------
+
+    @Test
+    void numberOfAnnotationsResponseRoundTrips() {
+        NumberOfAnnotationsResponse r =
+                new NumberOfAnnotationsResponse("http://c", 5, "urn:g", "SELECT *");
+        assertEquals("http://c", r.getComponentUrl());
+        assertEquals(5, r.getAnnotationCount());
+        assertEquals("urn:g", r.getGraph());
+        assertEquals("SELECT *", r.getSparqlGet());
+
+        r.setComponentUrl("http://c2");
+        r.setAnnotationCount(7);
+        r.setGraph("urn:g2");
+        r.setSparqlGet("ASK {}");
+        assertEquals("http://c2", r.getComponentUrl());
+        assertEquals(7, r.getAnnotationCount());
+        assertEquals("urn:g2", r.getGraph());
+        assertEquals("ASK {}", r.getSparqlGet());
+    }
+
+    // ---- QanaryQuestionAnsweringError ---------------------------------------
+
+    @Test
+    void questionAnsweringErrorExposesAllFields() {
+        URI q = URI.create("urn:question:1");
+        QanaryQuestionAnsweringError error = new QanaryQuestionAnsweringError(
+                q, QanaryQuestionAnsweringError.ErrorType.COMPONENT_EXECUTION_FAILED, "NER", "boom");
+        assertEquals(q, error.getQuestionUri());
+        assertEquals(QanaryQuestionAnsweringError.ErrorType.COMPONENT_EXECUTION_FAILED, error.getType());
+        assertEquals("NER", error.getComponent());
+        assertEquals("boom", error.getMessage());
+        assertNotNull(error.getTimestamp());
+    }
+
+    @Test
+    void questionAnsweringErrorTypeEnumIsComplete() {
+        // exercise valueOf/values for the enum
+        assertEquals(4, QanaryQuestionAnsweringError.ErrorType.values().length);
+        assertEquals(QanaryQuestionAnsweringError.ErrorType.PIPELINE_FAILURE,
+                QanaryQuestionAnsweringError.ErrorType.valueOf("PIPELINE_FAILURE"));
+    }
+}

--- a/service_config/jacoco-coverage-summary.py
+++ b/service_config/jacoco-coverage-summary.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Aggregate JaCoCo per-class line coverage across all Qanary modules and print a
+human-readable summary.
+
+Reads every ``**/target/site/jacoco/jacoco.csv`` produced by the ``jacoco:report``
+goal (run as part of ``mvn test``) and reports, per module and overall:
+
+  * line coverage percentage
+  * the list of classes whose line coverage is below the threshold (default 80%)
+
+The summary is written to ``$GITHUB_STEP_SUMMARY`` (GitHub Actions job summary)
+when that environment variable is set, and always to stdout.
+
+Exit code:
+  * 0 by default (report-only).
+  * If ``COVERAGE_ENFORCE=true``, exits 1 when any class is below the threshold,
+    so the coverage gate can fail the build once all classes meet it.
+
+The per-class gate itself is also enforced by the ``jacoco:check`` goal; enable it
+to fail the Maven build with ``-Djacoco.haltOnFailure=true``.
+"""
+import csv
+import glob
+import os
+import sys
+
+THRESHOLD = float(os.environ.get("COVERAGE_THRESHOLD", "80"))
+ENFORCE = os.environ.get("COVERAGE_ENFORCE", "false").lower() == "true"
+
+# Regression ratchet: enforced minimum *overall* line coverage (percent). The
+# build fails if overall coverage drops below this, so coverage cannot silently
+# regress even though the per-class 80% rule stays advisory (report-only).
+MIN_OVERALL = float(os.environ.get("COVERAGE_MIN_OVERALL", "0") or "0")
+
+# Enforced per-module floors, e.g. "qanary_commons=55,qanary_pipeline-template=48".
+MIN_MODULE = {}
+for _part in os.environ.get("COVERAGE_MIN_MODULE", "").split(","):
+    if "=" in _part:
+        _k, _v = _part.split("=", 1)
+        MIN_MODULE[_k.strip()] = float(_v)
+
+
+def load_csv(path):
+    classes = []
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            line_missed = int(row["LINE_MISSED"])
+            line_covered = int(row["LINE_COVERED"])
+            total = line_missed + line_covered
+            if total == 0:
+                continue  # interfaces / marker classes have no lines to cover
+            classes.append({
+                "name": (row["PACKAGE"] + "." + row["CLASS"]),
+                "covered": line_covered,
+                "total": total,
+                "pct": 100.0 * line_covered / total,
+            })
+    return classes
+
+
+def main():
+    csv_paths = sorted(glob.glob("**/target/site/jacoco/jacoco.csv", recursive=True))
+    if not csv_paths:
+        print("No JaCoCo reports found (expected **/target/site/jacoco/jacoco.csv). "
+              "Did 'mvn test' run?", file=sys.stderr)
+        return 0
+
+    lines = []
+    lines.append("## Test coverage (JaCoCo)\n")
+    lines.append(f"Per-class line-coverage threshold: **{THRESHOLD:.0f}%**\n")
+
+    grand_covered = grand_total = 0
+    below = []
+    module_pct = {}
+
+    for path in csv_paths:
+        module = path.split("/target/")[0]
+        classes = load_csv(path)
+        if not classes:
+            continue
+        mod_covered = sum(c["covered"] for c in classes)
+        mod_total = sum(c["total"] for c in classes)
+        grand_covered += mod_covered
+        grand_total += mod_total
+        mod_pct = 100.0 * mod_covered / mod_total if mod_total else 0.0
+        module_pct[module] = mod_pct
+        mod_below = [c for c in classes if c["pct"] < THRESHOLD]
+        below.extend((module, c) for c in mod_below)
+        floor = MIN_MODULE.get(module)
+        floor_note = f" (enforced floor {floor:.0f}%{' ✗' if mod_pct + 1e-9 < floor else ' ✓'})" if floor else ""
+        lines.append(f"### `{module}` — {mod_pct:.1f}% "
+                     f"({mod_covered}/{mod_total} lines, "
+                     f"{len(mod_below)}/{len(classes)} classes below threshold){floor_note}\n")
+
+    overall = 100.0 * grand_covered / grand_total if grand_total else 0.0
+    summary = (f"### Overall: **{overall:.1f}%** "
+               f"({grand_covered}/{grand_total} lines covered); "
+               f"{len(below)} class(es) below {THRESHOLD:.0f}%\n")
+    lines.insert(1, summary)
+
+    if below:
+        lines.append("\n<details><summary>Classes below threshold</summary>\n")
+        lines.append("\n| Module | Class | Lines | Coverage |")
+        lines.append("| --- | --- | ---: | ---: |")
+        for module, c in sorted(below, key=lambda x: (x[0], x[1]["pct"])):
+            lines.append(f"| {module} | `{c['name']}` | {c['total']} | {c['pct']:.1f}% |")
+        lines.append("\n</details>\n")
+
+    report = "\n".join(lines)
+    print(report)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as f:
+            f.write(report + "\n")
+
+    # ---- enforced regression gate (ratchet) --------------------------------
+    failures = []
+    if MIN_OVERALL and overall + 1e-9 < MIN_OVERALL:
+        failures.append(f"overall coverage {overall:.1f}% < required {MIN_OVERALL:.0f}%")
+    for module, floor in MIN_MODULE.items():
+        actual = module_pct.get(module)
+        if actual is not None and actual + 1e-9 < floor:
+            failures.append(f"module {module} coverage {actual:.1f}% < required {floor:.0f}%")
+    if failures:
+        print("\nCOVERAGE GATE FAILED (regression):", file=sys.stderr)
+        for f in failures:
+            print("  - " + f, file=sys.stderr)
+        return 1
+
+    # ---- advisory per-class enforcement (off by default) -------------------
+    if ENFORCE and below:
+        print(f"\nCOVERAGE GATE FAILED: {len(below)} class(es) below "
+              f"{THRESHOLD:.0f}% line coverage.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/service_config/spotbugs-enforced.xml
+++ b/service_config/spotbugs-enforced.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs *enforced* gate (quality task A1).
+
+  Used as an includeFilter for `spotbugs:check -Dspotbugs.failOnError=true` in CI:
+  only the high-severity correctness and security patterns listed here fail the
+  build. They are all currently at ZERO across the project (the correctness ones
+  were just fixed), so the gate is green today and fails only on a regression /
+  newly introduced instance.
+
+  The full SpotBugs report (`spotbugs:spotbugs`, report-only) still surfaces every
+  finding for gradual triage; widen this list as more categories are driven to zero.
+-->
+<FindBugsFilter>
+  <!-- correctness bugs fixed in task A1 -->
+  <Match><Bug pattern="IL_INFINITE_RECURSIVE_LOOP"/></Match>
+  <Match><Bug pattern="ES_COMPARING_PARAMETER_STRING_WITH_EQ"/></Match>
+  <Match><Bug pattern="ES_COMPARING_STRINGS_WITH_EQ"/></Match>
+  <Match><Bug pattern="OS_OPEN_STREAM"/></Match>
+  <Match><Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH"/></Match>
+
+  <!-- classically severe correctness patterns (currently absent; keep absent) -->
+  <Match><Bug pattern="RpC_REPEATED_CONDITIONAL_TEST"/></Match>
+  <Match><Bug pattern="NP_ALWAYS_NULL"/></Match>
+  <Match><Bug pattern="NP_GUARANTEED_DEREF"/></Match>
+  <Match><Bug pattern="DMI_INVOKING_TOSTRING_ON_ARRAY"/></Match>
+
+  <!-- severe security patterns (FindSecBugs); currently absent, fail if introduced -->
+  <Match><Bug pattern="SQL_INJECTION_JDBC"/></Match>
+  <Match><Bug pattern="SQL_INJECTION_SPRING_JDBC"/></Match>
+  <Match><Bug pattern="SQL_INJECTION_JPA"/></Match>
+  <Match><Bug pattern="SQL_INJECTION_HIBERNATE"/></Match>
+  <Match><Bug pattern="COMMAND_INJECTION"/></Match>
+  <Match><Bug pattern="XXE_SAXPARSER"/></Match>
+  <Match><Bug pattern="XXE_XMLREADER"/></Match>
+  <Match><Bug pattern="XXE_DOCUMENT"/></Match>
+  <Match><Bug pattern="HARD_CODE_PASSWORD"/></Match>
+  <Match><Bug pattern="DMI_CONSTANT_DB_PASSWORD"/></Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary

Lands the **framework quality hardening** (already reviewed in #388) onto `master`.

When #387 and #388 were merged, #388 targeted `task-new-frontend` rather than `master`, so the hardening never reached `master`. This PR brings it across — the diff is exactly the hardening layer:

- **JaCoCo** coverage 30% → ~62% + a regression-ratchet CI gate
- ~24 new unit + integration tests; triplestore connector conformance suite
- **SpotBugs + FindSecBugs** (enforced curated gate), **PIT** mutation testing, **OWASP dependency-check**, **gitleaks** secret-scan, **maven-enforcer** (JDK 21+), **Spotless**
- Three real bug fixes found by SpotBugs (infinite recursion in `QanaryTripleStoreProxy.update`; broken `QanaryExceptionServiceCallNotOk` message; reader leak) + smaller fixes
- `BUILDING.md` and `SECURITY.md`

Full description in #388. E2E verified: the pipeline answers "Sam Panopoulos" against the offline stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
