### PR TITLE
Fix CI gates broken by #387/#388: secret-scan license + GPG-on-install

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
           echo "No artifacts to be released."
         else
           echo "Releasing artifacts: $ARTIFACTS_TO_BE_RELEASED"
-          mvn clean deploy -Dgpg.keyname="$MAVEN_GPG_KEYNAME" -pl "$ARTIFACTS_TO_BE_RELEASED"
+          mvn clean deploy -Dgpg.skip=false -Dgpg.keyname="$MAVEN_GPG_KEYNAME" -pl "$ARTIFACTS_TO_BE_RELEASED"
         fi
       env:
         MAVEN_TOKEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,8 +1,15 @@
 name: Secret scan (gitleaks)
 
-# Scans the working tree and the full git history for leaked secrets
-# (credentials, API keys, etc.). Helps prevent a recurrence of the historically
-# committed Virtuoso credential (see SECURITY.md, task 1.6).
+# Scans the working tree and full git history for leaked secrets.
+#
+# NOTE: we invoke the open-source gitleaks CLI directly (via its Docker image)
+# rather than gitleaks/gitleaks-action@v2, because that action requires a paid
+# GITLEAKS_LICENSE for GitHub organizations. The CLI itself is free.
+#
+# Known pre-existing findings in old history (removed Babelfy/Alchemy/TextRazor
+# components + the legacy Virtuoso credential) are allowlisted by fingerprint in
+# .gitleaksignore; remediation is tracked in SECURITY.md (task 1.6). The gate
+# still fails on any NEW secret introduced in a pull request.
 on:
   pull_request:
   push:
@@ -16,11 +23,12 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # full history so the scan covers past commits too
 
-      - name: gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: gitleaks (open-source CLI, license-free)
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" \
+            zricethezav/gitleaks:latest \
+            detect --source=/repo --redact --verbose --no-banner

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,20 @@
+# gitleaks allowlist — KNOWN HISTORICAL findings only.
+# These secrets live in OLD commits (removed components: Babelfy/Alchemy/TextRazor
+# API keys, and the legacy Virtuoso credential in service_config/files/pipeline).
+# They are NOT in the current tree. Remediation (rotation / optional history scrub)
+# is tracked in SECURITY.md (task 1.6). Allowlisting keeps the secret-scan gate
+# green on known history while still failing on any NEW secret introduced in a PR.
+12fed12e03fd9ba995dda4d7566f3f6c478fedac:service_config/files/pipeline:generic-api-key:5
+c04cb95f6c7bd36df9b32c3241c203e275dc7308:qanary_component-NER-Babelfy/src/main/java/eu/wdaqua/qanary/mypackage/Babelfy.java:generic-api-key:64
+c04cb95f6c7bd36df9b32c3241c203e275dc7308:qanary_component-NED-Babelfy/src/main/java/eu/wdaqua/qanary/mypackage/BabelfyNED.java:generic-api-key:61
+c04cb95f6c7bd36df9b32c3241c203e275dc7308:qanary_component-NER-TextRazor/src/main/java/eu/wdaqua/qanary/mypackage/TextRazor.java:generic-api-key:59
+c04cb95f6c7bd36df9b32c3241c203e275dc7308:.metadata/.plugins/org.eclipse.e4.workbench/workbench.xmi:generic-api-key:470
+191902116780e8cfbdd110fac23588856626d494:qanary_component-Alchemy-NERD/src/main/java/eu/wdaqua/qanary/alchemy/Alchemy.java:generic-api-key:36
+b50fb90e13c3ef290080cd142e6c5cfd36d65d70:qanary_component-Alchemy-NERD/src/main/java/eu/wdaqua/qanary/alchemy/Alchemy.java:generic-api-key:37
+c4d241fc7bd4dc8f7053c8fbb698a2c02e3ee29c:qanary_component-Alchemy-NERD/src/main/java/eu/wdaqua/qanary/alchemy/Alchemy.java:generic-api-key:39
+e60c3e2b33370ff4252cfc8fc4adff0d3822b7b1:qanary_component-alchemy/src/main/java/eu/wdaqua/qanary/alchemy/Alchemy.java:generic-api-key:52
+abfa9136c9aa70130e49ebb0b639afc21c6b9ff4:qanary_component-alchemy/src/main/java/eu/wdaqua/qanary/alchemy/Alchemy.java:generic-api-key:52
+072529f809c5bca74ff74c0386d18f723297c26b:qanary_component-alchemy2/src/main/java/eu/wdaqua/qanary/component/Alchemy2.java:generic-api-key:54
+bbaedf09b4213e2f83e0685a5fcf122db4ea6eaf:qanary_component-alchemy2/src/main/java/eu/wdaqua/qanary/component/Alchemy2.java:generic-api-key:54
+94180923f0d75a7377fea275914d5cf2a555d65e:qanary_component-alchemy/src/main/java/eu/wdaqua/qanary/Alchemy/AlchemyComponent.java:generic-api-key:54
+28acb99fbf6f5819e6f0cb4b07fcb3421a6f27bf:qanary_component-alchemy/src/main/java/eu/wdaqua/qanary/Alchemy/AlchemyComponent.java:generic-api-key:54

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <central-publishing-plugin.version>0.8.0</central-publishing-plugin.version>
     <maven-gpg-plugin.version>3.2.0</maven-gpg-plugin.version>
+    <!-- GPG signing (sign-artifacts execution) is bound to the verify phase, so it
+         would fire on every `mvn install` and fail in CI/local builds that have no
+         signing key. Default it OFF; the release workflow (maven.yml) re-enables it
+         with -Dgpg.skip=false alongside the key from secrets. -->
+    <gpg.skip>true</gpg.skip>
     <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
     <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>


### PR DESCRIPTION
## Summary

#401 landed the framework hardening on master — including the new secret-scan (gitleaks) workflow. But that workflow used `gitleaks/gitleaks-action@v2`, which **requires a paid `GITLEAKS_LICENSE` for GitHub organizations** (WDAqua), so the check fails at startup on every PR *without ever scanning* (`[WDAqua] is an organization. License key is required.`).

This PR fixes the gate (two commits already on `task-new-frontend`):

1. **Switch to the open-source gitleaks CLI** (via its Docker image) instead of the license-gated action — free, and honours `.gitleaksignore`.
2. **Allowlist known historical findings** in `.gitleaksignore` (14 fingerprints: long-removed Babelfy/Alchemy/TextRazor API keys + the legacy Virtuoso credential in `service_config/files/pipeline`). None are in the current tree; remediation stays tracked in `SECURITY.md` (task 1.6).

Verified locally: `gitleaks detect` → **"no leaks found", exit 0**. The gate now passes on known history while still failing on any **new** secret introduced in a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
