### PR TITLE
Fix AspectJ test-compile CI flake + commons-lang3 3.18 for commons-configuration2 2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
     <virtuoso-jdbc.version>3.123</virtuoso-jdbc.version>
     <commons-cli.version>1.9.0</commons-cli.version>
     <commons-configuration2.version>2.15.0</commons-configuration2.version>
+    <!-- commons-configuration2 2.15.x calls commons-lang3 ObjectUtils.getIfNull(Object,Object),
+         which only exists in commons-lang3 >= 3.18.0. Spring Boot 3.5 pins an older 3.17.0,
+         so without this override the pipeline fails at startup with NoSuchMethodError. -->
+    <commons-lang3.version>3.18.0</commons-lang3.version>
     <gson.version>2.13.2</gson.version>
     <jakarta-xml-bind.version>4.0.4</jakarta-xml-bind.version>
 
@@ -256,8 +260,15 @@
           <executions>
             <execution>
               <goals>
+                <!-- Only weave MAIN classes. The test-compile weave was removed:
+                     re-weaving the already-woven qa.commons dependency
+                     (weaveDependencies) during test-compile triggers AspectJ's
+                     non-deterministic "key not found in wovenClassFile" abort,
+                     which made CI flaky (~50%). Test sources are still compiled by
+                     maven-compiler-plugin's default-testCompile (javac); the aspects
+                     advise framework MAIN methods, which stay woven, so runtime and
+                     test behaviour are unchanged. -->
                 <goal>compile</goal>
-                <goal>test-compile</goal>
               </goals>
             </execution>
           </executions>

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -387,16 +387,13 @@
                             <goal>compile</goal>
                         </goals>
                     </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
+                    <!-- No test-compile weave: the parent's shared execution now
+                         weaves MAIN classes only (test-compile re-wove the already
+                         woven qa.commons and hit AspectJ's "key not found in
+                         wovenClassFile" flake). The earlier skip=true execution here
+                         was ineffective because the parent's default execution merged
+                         the test-compile goal back in; removed now that the parent no
+                         longer declares it. -->
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Summary

Two build-stability fixes (both validated by `mvn clean test` **and** the offline "Sam Panopoulos" E2E):

### 1. AspectJ `key not found in wovenClassFile` CI flake (~50% of runs)
The shared aspectj-maven-plugin execution wove both `compile` **and** `test-compile`. During test-compile it **re-wove the already-woven `qa.commons`** dependency (`weaveDependencies`), which non-deterministically aborts with `key not found in wovenClassFile` — the flake that has been failing CI on essentially every PR.

**Fix:** weave **main classes only** (removed `test-compile` from the parent's shared execution + the redundant `skip=true` execution in `qanary_pipeline-template`). Test sources still compile via `maven-compiler-plugin`'s `default-testCompile` (javac); the aspects advise framework **main** methods, which stay woven, so runtime and test behaviour are unchanged.

### 2. commons-lang3 `NoSuchMethodError` (regression already on master)
`commons-configuration2` 2.15.x (bumped via #396) calls `ObjectUtils.getIfNull(Object,Object)`, which only exists in **commons-lang3 ≥ 3.18.0**. Spring Boot 3.5 pins 3.17.0, so the pipeline failed at startup:
```
NoSuchMethodError: org.apache.commons.lang3.ObjectUtils.getIfNull(Object, Object)
  at org.apache.commons.configuration2.io.FileLocatorUtils...
  creating bean 'componentsToIndexMap'
```
**Fix:** override `commons-lang3.version` → 3.18.0. (This also unblocks #397, which bumps commons-configuration2 to 2.15.1.)

## Validation
- `mvn clean test` — **all modules green** (the 49 pipeline tests that were failing on the NoSuchMethodError now pass; no AspectJ flake).
- Offline E2E — pipeline answers **"Sam Panopoulos"**, LD-Java aspect contributed 3 annotations (main weave intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
