### PR TITLE
Enable Jena 6.1.0 (with commons-lang3 alignment) — supersedes #389

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <qanary.components.version>4.0.0</qanary.components.version>
 
     <!-- shared library versions -->
-    <jena.version>5.3.0</jena.version>
+    <jena.version>6.1.0</jena.version>
     <spring-boot-admin.version>3.5.9</spring-boot-admin.version>
     <springdoc.version>2.8.17</springdoc.version>
     <stardog.version>8.2.2</stardog.version>
@@ -89,6 +89,18 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Pin commons-lang3 explicitly so it wins over transitive resolution.
+           Jena 6.x's org.apache.jena.atlas.lib.AlarmClock needs
+           BasicThreadFactory.builder() and commons-configuration2 2.15.x needs
+           ObjectUtils.getIfNull(Object,Object) — both only exist in >= 3.18.0,
+           while Spring Boot 3.5 pins 3.17.0 and Jena's transitive otherwise drags
+           it back down (the commons-lang3.version property alone doesn't win). -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+
       <!-- internal Qanary artifacts -->
       <dependency>
         <groupId>eu.wdaqua.qanary</groupId>


### PR DESCRIPTION
## Summary

Enables **Jena 5.3.0 → 6.1.0** by fixing the dependency conflict that makes the bare bump (#389) fail CI.

**The problem #389 alone hits:** Jena 6's `org.apache.jena.atlas.lib.AlarmClock` calls `commons-lang3` `BasicThreadFactory.builder()`, which — like `commons-configuration2` 2.15's `ObjectUtils.getIfNull` — only exists in **commons-lang3 ≥ 3.18.0**. Spring Boot 3.5 pins 3.17.0, and once Jena 6 is on the classpath the `commons-lang3.version=3.18.0` *property* no longer wins (Jena's transitive drags it back to 3.17.0), so the pipeline/tests fail at runtime:
```
NoSuchMethodError: commons-lang3 BasicThreadFactory.builder()
  → NoClassDefFoundError: org.apache.jena.atlas.lib.AlarmClock
```

**Fix:** add an explicit `commons-lang3` `<dependencyManagement>` entry so the pin wins deterministically over transitive mediation (covers both Jena 6's `builder()` and commons-configuration2's `getIfNull`).

## Validation
- `mvn clean test` — **all modules green** (the qa.commons connector tests that failed on `builder()` now pass).
- Offline **E2E** — pipeline answers **"Sam Panopoulos"** (Jena 6.1 + commons-lang3 3.18 + temurin-25 base; Virtuoso/VirtGraph runtime path exercised).

**Supersedes #389.** Note: this is a *major* framework upgrade — recommend confirming the downstream WDAqua components before merging, even though the framework itself is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
