### PR TITLE
Publish the mvn.reactor parent POM to Maven Central (unblocks 4.0.0 release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,32 @@
   <version>4.0.0</version>
   <packaging>pom</packaging>
 
+  <!-- Metadata required by Maven Central (the released modules use this as their
+       parent, so it must itself be published with complete metadata). -->
+  <name>Qanary reactor (parent POM)</name>
+  <description>Shared parent POM and dependency/plugin management for the Qanary
+    question answering framework modules.</description>
+  <url>https://github.com/WDAqua/Qanary</url>
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <name>Andreas Both</name>
+      <email>andreas.both@htwk-leipzig.de</email>
+      <organization>WDAqua</organization>
+      <organizationUrl>http://wdaqua.eu/</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:git://github.com/WDAqua/Qanary.git</connection>
+    <developerConnection>scm:git:ssh://github.com/WDAqua/Qanary.git</developerConnection>
+    <url>https://github.com/WDAqua/Qanary</url>
+  </scm>
+
   <modules>
     <module>qanary_component-archetype</module>
     <module>qanary_commons</module>

--- a/service_config/version_check.sh
+++ b/service_config/version_check.sh
@@ -6,6 +6,20 @@ GROUP_PATH=$(echo "$GROUP_ID" | tr '.' '/')
 artifacts=(qanary_commons qanary_pipeline-template qanary_component-template qanary_component-parent)
 artifacts_to_be_released=()
 
+# The shared parent POM (mvn.reactor) must also be published to Maven Central so the
+# released modules can resolve it as their parent. Check the reactor root pom and
+# release it (as ".") when it is missing — deploy it first so it is in the bundle.
+ROOT_ARTIFACT_ID=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='artifactId']/text()" pom.xml)
+ROOT_VERSION=$(xmllint --xpath "/*[local-name()='project']/*[local-name()='version']/text()" pom.xml)
+ROOT_URL="https://repo1.maven.org/maven2/$GROUP_PATH/$ROOT_ARTIFACT_ID/$ROOT_VERSION/$ROOT_ARTIFACT_ID-$ROOT_VERSION.pom"
+ROOT_HTTP_STATUS=$(curl --head --silent --output /dev/null --write-out "%{http_code}" "$ROOT_URL")
+if [ "$ROOT_HTTP_STATUS" -eq 200 ]; then
+    echo "Parent $ROOT_ARTIFACT_ID version $ROOT_VERSION exists in Maven Central."
+else
+    echo "Parent $ROOT_ARTIFACT_ID version $ROOT_VERSION does not exist in Maven Central; releasing the reactor root."
+    artifacts_to_be_released+=(".")
+fi
+
 for artifact in "${artifacts[@]}"; do
     echo "Checking version in: $artifact"
     while read -r file; do


### PR DESCRIPTION
## Why the 4.0.0 Maven Central release fails

The release workflow uploads the signed bundle to central.sonatype.com but Central rejects it: `Deployment ... failed while publishing`. Root cause: the 4.0.0 modules use a **new shared parent `eu.wdaqua.qanary:mvn.reactor`** (3.x used `spring-boot-starter-parent` directly). That parent is **not on Central**, **missing required metadata**, and **not in `version_check.sh`'s release list** — so the modules reference a parent Central can't resolve.

## Fix
- Add Central-required metadata to the parent pom (`name`/`description`/`url`/`licenses`/`developers`/`scm`).
- `version_check.sh` now also releases the reactor root (`.`) when `mvn.reactor` is absent from Central, so the parent is bundled & published alongside the four modules.

Merging this triggers the **Maven Central Release** workflow, which should now publish `mvn.reactor`, `qa.commons`, `qa.pipeline`, `qa.component`, `qa.qanarycomponent-parent` at 4.0.0. Unblocks WDAqua/Qanary-question-answering-components#388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)