### PR TITLE
Release 4.0.1: fix qa.component test-jar leaking a test bean into downstream components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <artifactId>mvn.reactor</artifactId>
   <!-- Release version (not SNAPSHOT): this parent is published to Maven Central
        so the released modules can resolve it as their parent. -->
-  <version>4.0.0</version>
+  <version>4.0.1</version>
   <packaging>pom</packaging>
 
   <!-- Metadata required by Maven Central (the released modules use this as their
@@ -60,8 +60,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Qanary artifact versions (pinned; task 2.1) -->
-    <qanary.version>4.0.0</qanary.version>
-    <qanary.components.version>4.0.0</qanary.components.version>
+    <qanary.version>4.0.1</qanary.version>
+    <qanary.components.version>4.0.1</qanary.components.version>
 
     <!-- shared library versions -->
     <jena.version>5.3.0</jena.version>

--- a/qald-evaluator/pom.xml
+++ b/qald-evaluator/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>
         <artifactId>mvn.reactor</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!-- java.version inherited from parent (task 2.2) -->

--- a/qanary_commons/pom.xml
+++ b/qanary_commons/pom.xml
@@ -4,11 +4,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary</groupId>
     <artifactId>qa.commons</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>
         <artifactId>mvn.reactor</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/qanary_component-archetype/pom.xml
+++ b/qanary_component-archetype/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>eu.wdaqua.qanary.component</groupId>
     <artifactId>qa.qanarycomponent-archetype</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <packaging>maven-archetype</packaging>
 
     <name>qanary-component-archetype</name>

--- a/qanary_component-parent/pom.xml
+++ b/qanary_component-parent/pom.xml
@@ -5,18 +5,18 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary</groupId>
     <artifactId>qa.qanarycomponent-parent</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <packaging>pom</packaging>
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>
         <artifactId>mvn.reactor</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
         <!-- java.version, spring-boot-admin.version, springdoc.version inherited from parent (task 2.2) -->
-        <qanary.component.version>4.0.0</qanary.component.version>
-        <qanary.commons.version>4.0.0</qanary.commons.version>
+        <qanary.component.version>4.0.1</qanary.component.version>
+        <qanary.commons.version>4.0.1</qanary.commons.version>
         <json-path.version>3.0.0</json-path.version>
     </properties>
 

--- a/qanary_component-template/pom.xml
+++ b/qanary_component-template/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.wdaqua.qanary</groupId>
     <artifactId>qa.component</artifactId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>
         <artifactId>mvn.reactor</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!-- java.version, spring-boot-admin.version, jena.version inherited from parent (task 2.2) -->
@@ -217,6 +217,20 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <!-- Components depend on this test-jar for
+                                 AbstractSwaggerUiAvailabilityTest, but it must NOT
+                                 ship QanaryComponentIntegrationTest: that class
+                                 declares a nested @SpringBootApplication and a
+                                 'testQanaryComponent' @Bean, which leak into
+                                 downstream component-scans and cause
+                                 NoUniqueBeanDefinitionException(QanaryComponent).
+                                 The test still runs in this module's own build;
+                                 it is only excluded from the published artifact. -->
+                            <excludes>
+                                <exclude>**/QanaryComponentIntegrationTest*.class</exclude>
+                            </excludes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/qanary_pipeline-template/pom.xml
+++ b/qanary_pipeline-template/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>qa.pipeline</artifactId>
     <groupId>eu.wdaqua.qanary</groupId>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <parent>
         <groupId>eu.wdaqua.qanary</groupId>
         <artifactId>mvn.reactor</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>


### PR DESCRIPTION
## Why
The published `qa.component-4.0.0-tests.jar` ships `QanaryComponentIntegrationTest`, whose nested `@SpringBootApplication` + `testQanaryComponent` `@Bean` leak into downstream component `@SpringBootTest` scans. All 59 components depend on this test-jar (for `AbstractSwaggerUiAvailabilityTest`), so they hit `NoUniqueBeanDefinitionException: QanaryComponent … found 2: <RealComponent>, testQanaryComponent`. (Blocks WDAqua/Qanary-question-answering-components#388.) 4.0.0 is immutable on Central → release **4.0.1**.

## Changes
- **Exclude `QanaryComponentIntegrationTest*` from the published test-jar** (it still runs in this module's build; `AbstractSwaggerUiAvailabilityTest` still ships).
- **Bump all qanary artifacts 4.0.0 → 4.0.1** (parent, 4 modules, parent refs, `qanary.version`/`qanary.components.version`); qald-evaluator stays 2.0.0.

## Validation
- `mvn clean install` green; `qa.component-4.0.1-tests.jar` confirmed to NOT contain the leaky classes (keeps `AbstractSwaggerUiAvailabilityTest`).
- Offline E2E answers **"Sam Panopoulos"**.

Merging triggers the Maven Central Release workflow to publish 4.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)