### PR TITLE
Implement extended health endpoint (#405)

### DIFF
--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/health/QanaryHealthIndicator.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/health/QanaryHealthIndicator.java
@@ -1,0 +1,133 @@
+package eu.wdaqua.qanary.health;
+
+import de.codecentric.boot.admin.server.domain.entities.Instance;
+import eu.wdaqua.qanary.QanaryComponentRegistrationChangeNotifier;
+import eu.wdaqua.qanary.business.QanaryConfigurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extended Qanary health information exposed under {@code /actuator/health}
+ * (and mirrored at {@code /health} by {@link QanaryHealthWebController}), per
+ * issue #405. Contributes, under the {@code qanary} key:
+ * <ul>
+ *   <li>{@code version} – the running Qanary pipeline version (from build-info / the pom)</li>
+ *   <li>{@code frontend} – {@code {availability, url}} of the embedded /qa frontend</li>
+ *   <li>{@code components} – the currently registered Qanary components and their info</li>
+ *   <li>{@code triplestore} – {@code {availability}} verified via a trivial SPARQL ASK</li>
+ * </ul>
+ * The overall status is reported DOWN when the triplestore (essential to the
+ * pipeline) cannot be reached.
+ */
+@Component("qanary")
+public class QanaryHealthIndicator implements HealthIndicator {
+
+    private static final Logger logger = LoggerFactory.getLogger(QanaryHealthIndicator.class);
+
+    private final QanaryComponentRegistrationChangeNotifier componentRegistry;
+    private final QanaryConfigurator qanaryConfigurator;
+    private final ObjectProvider<BuildProperties> buildProperties;
+    private final String frontendUrl;
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(3)).build();
+
+    public QanaryHealthIndicator( //
+            QanaryComponentRegistrationChangeNotifier componentRegistry, //
+            QanaryConfigurator qanaryConfigurator, //
+            ObjectProvider<BuildProperties> buildProperties, //
+            @Value("${server.host:http://localhost}") String serverHost, //
+            @Value("${server.port:8080}") String serverPort) {
+        this.componentRegistry = componentRegistry;
+        this.qanaryConfigurator = qanaryConfigurator;
+        this.buildProperties = buildProperties;
+        String host = serverHost.endsWith("/") ? serverHost.substring(0, serverHost.length() - 1) : serverHost;
+        this.frontendUrl = host + ":" + serverPort + "/qa";
+    }
+
+    @Override
+    public Health health() {
+        Health.Builder health = Health.up();
+        health.withDetail("version", version());
+
+        boolean frontendAvailable = isReachable(frontendUrl);
+        Map<String, Object> frontend = new LinkedHashMap<>();
+        frontend.put("availability", frontendAvailable);
+        frontend.put("url", frontendUrl);
+        health.withDetail("frontend", frontend);
+
+        health.withDetail("components", components());
+
+        boolean triplestoreAvailable = isTriplestoreAvailable();
+        health.withDetail("triplestore", Map.of("availability", triplestoreAvailable));
+
+        // the triplestore is essential; surface DOWN when it is unreachable
+        if (!triplestoreAvailable) {
+            health.down();
+        }
+        return health.build();
+    }
+
+    private String version() {
+        BuildProperties bp = buildProperties.getIfAvailable();
+        if (bp != null && bp.getVersion() != null) {
+            return bp.getVersion();
+        }
+        String implementationVersion = getClass().getPackage().getImplementationVersion();
+        return implementationVersion != null ? implementationVersion : "unknown";
+    }
+
+    private List<Map<String, Object>> components() {
+        List<Map<String, Object>> components = new ArrayList<>();
+        for (Map.Entry<String, Instance> entry : componentRegistry.getAvailableComponents().entrySet()) {
+            Instance instance = entry.getValue();
+            Map<String, Object> info = new LinkedHashMap<>();
+            info.put("name", entry.getKey());
+            info.put("status", instance.getStatusInfo().getStatus());
+            if (instance.getRegistration() != null) {
+                info.put("serviceUrl", instance.getRegistration().getServiceUrl());
+                info.put("managementUrl", instance.getRegistration().getManagementUrl());
+                info.put("healthUrl", instance.getRegistration().getHealthUrl());
+            }
+            components.add(info);
+        }
+        return components;
+    }
+
+    private boolean isTriplestoreAvailable() {
+        try {
+            // trivial, side-effect-free query: a reachable, responsive triplestore answers true
+            return qanaryConfigurator.getQanaryTripleStoreConnector().ask("ASK {}");
+        } catch (Exception e) {
+            logger.warn("triplestore health check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean isReachable(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofSeconds(3)).GET().build();
+            HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
+            return response.statusCode() >= 200 && response.statusCode() < 400;
+        } catch (Exception e) {
+            logger.warn("frontend health check failed for {}: {}", url, e.getMessage());
+            return false;
+        }
+    }
+}

--- a/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/health/QanaryHealthWebController.java
+++ b/qanary_pipeline-template/src/main/java/eu/wdaqua/qanary/health/QanaryHealthWebController.java
@@ -1,0 +1,27 @@
+package eu.wdaqua.qanary.health;
+
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Serves the same information as {@code /actuator/health} at the convenience
+ * path {@code /health} (issue #405), so users get the extended Qanary status
+ * (version, frontend, components, triplestore — see {@link QanaryHealthIndicator})
+ * without knowing the actuator base path.
+ */
+@RestController
+public class QanaryHealthWebController {
+
+    private final HealthEndpoint healthEndpoint;
+
+    public QanaryHealthWebController(HealthEndpoint healthEndpoint) {
+        this.healthEndpoint = healthEndpoint;
+    }
+
+    @GetMapping("/health")
+    public HealthComponent health() {
+        return healthEndpoint.health();
+    }
+}

--- a/qanary_pipeline-template/src/main/resources/application.properties
+++ b/qanary_pipeline-template/src/main/resources/application.properties
@@ -122,3 +122,7 @@ pipeline.as.component=false
 #### Is a default value, pass the url to the explanation service (including the /explain path)
 explanation.service=http://localhost:4000/explain
 rest.template.setting=logging
+
+### Extended health endpoint (issue #405): show the full Qanary status details
+### (version, frontend, components, triplestore) at /actuator/health and /health.
+management.endpoint.health.show-details=always


### PR DESCRIPTION
Closes #405.

Adds a Qanary `HealthIndicator` contributing to **/actuator/health** (mirrored at **/health** via a small controller) with the DoD fields:
- **version** — running pipeline version (build-info / pom)
- **frontend** — `{ availability (HTTP-checked), url }`
- **components** — currently registered components (name, status, service/management/health URLs)
- **triplestore** — `{ availability }` via a trivial SPARQL `ASK`

Overall status reports **DOWN** if the essential triplestore is unreachable. `management.endpoint.health.show-details=always`.

**Validated** on the offline stack: `/health` returns version 4.0.1, frontend up, 4 components, triplestore up; `/actuator/health` parity; pipeline still answers "Sam Panopoulos".

🤖 Generated with [Claude Code](https://claude.com/claude-code)