### PR TITLE
Replace Whitelabel error pages with a Qanary-designed page (#407)

### DIFF
--- a/qanary_pipeline-template/src/main/resources/templates/error.html
+++ b/qanary_pipeline-template/src/main/resources/templates/error.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Qanary — Error</title>
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <!-- reuse the /qa frontend look & feel (issue #407) -->
+  <link rel="stylesheet" href="/qanary-ui/styles.css">
+  <style>
+    /* self-contained layout so the page renders even if styles.css is unavailable;
+       colours fall back to the Qanary palette defined in styles.css :root */
+    body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+           background: var(--bg, #f3f7f8); color: var(--ink, #15202b); }
+    .topbar { display: flex; align-items: center; gap: 14px; padding: 16px 24px;
+              background: var(--brand, linear-gradient(135deg, #16a87a, #1d6f9c)); }
+    .topbar img { height: 34px; }
+    .topbar .tagline { color: #fff; opacity: .9; font-size: .95rem; }
+    .wrap { max-width: 760px; margin: 40px auto; padding: 0 20px; }
+    .card { background: var(--card, #fff); border: 1px solid var(--line, #dde6ea);
+            border-radius: var(--radius, 14px); padding: 28px 30px;
+            box-shadow: 0 6px 24px rgba(0,0,0,.06); }
+    .code { font-size: 3rem; font-weight: 700; margin: 0;
+            background: var(--brand, linear-gradient(135deg, #16a87a, #1d6f9c));
+            -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; }
+    .reason { color: var(--muted, #5c6b78); margin: 4px 0 0; }
+    .msg { margin: 16px 0 0; padding: 12px 14px; background: var(--field, #f3f7f8);
+           border-radius: 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+           font-size: .9rem; word-break: break-word; }
+    h2 { margin: 28px 0 10px; font-size: 1.05rem; }
+    .links { list-style: none; padding: 0; margin: 0; display: grid; gap: 10px;
+             grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+    .links a { display: block; padding: 12px 14px; text-decoration: none;
+               color: var(--accent, #0f8a7a); background: var(--field, #f3f7f8);
+               border: 1px solid var(--line, #dde6ea); border-radius: 10px; font-weight: 600; }
+    .links a:hover { border-color: var(--accent, #0f8a7a); }
+    .links small { display: block; color: var(--muted, #5c6b78); font-weight: 400; margin-top: 2px; }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <img src="/qanary-ui/logo-qanary.svg" alt="Qanary">
+    <span class="tagline">Question Answering pipeline</span>
+  </header>
+  <main class="wrap">
+    <div class="card">
+      <p class="code" th:text="${status} ?: 'Error'">500</p>
+      <p class="reason" th:text="${error} ?: 'Something went wrong'">Internal Server Error</p>
+      <p class="msg" th:if="${message != null and message != ''}" th:text="${message}">details</p>
+      <p class="msg" th:if="${path != null}">at <span th:text="${path}">/path</span></p>
+
+      <h2>Where to go next</h2>
+      <ul class="links">
+        <li><a href="/qa">Qanary frontend <small>ask a question (/qa)</small></a></li>
+        <li><a href="/health">Health <small>system status (/health)</small></a></li>
+        <li><a href="/swagger-ui">API / Swagger UI <small>REST API docs</small></a></li>
+        <li><a href="/applications">Components overview <small>Spring Boot Admin</small></a></li>
+        <li><a href="https://github.com/WDAqua/Qanary">GitHub <small>WDAqua/Qanary</small></a></li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Closes #407.

Adds `templates/error.html` (picked up automatically by Spring Boot's `DefaultErrorViewResolver`), styled to match the **/qa** frontend (reuses `/qanary-ui/styles.css` + the Qanary logo). It shows the error status/message and links to: the **/qa** frontend, **/health**, the **Swagger UI** (/swagger-ui), the **Spring Boot Admin** component overview (/applications), and the **GitHub** repository.

**Validated** on the running pipeline: a 404 returns the Qanary-styled page (no `Whitelabel` markup), with the status code and all five links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)