### PR TITLE
ci: fix Docker Image CI — check out repo before Set up JDK (Maven cache)

### DIFF
--- a/.github/workflows/docker-deployment.yml
+++ b/.github/workflows/docker-deployment.yml
@@ -10,6 +10,9 @@ jobs:
     env:
       VIRTUOSO_PASSWORD: ${{ secrets.VIRTUOSO_PASSWORD }}
     steps:
+      - name: Clone local Repository
+        uses: actions/checkout@v7
+
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -22,9 +25,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Clone local Repository
-        uses: actions/checkout@v7
 
       - name: Build the Docker images and Push to Dockerhub
         run: bash -c ./service_config/build_images.sh


### PR DESCRIPTION
## Problem
**Docker Image CI** (`.github/workflows/docker-deployment.yml`) has failed on **every push to master** since 2026-06-21 (e.g. run [27948505182](https://github.com/WDAqua/Qanary/actions/runs/27948505182), triggered by the #413 merge). It dies at the **Set up JDK** step with:

```
##[error]No file in /home/runner/work/Qanary/Qanary matched to [**/pom.xml], make sure you have checked out the target repository
```

## Cause
The job ran `actions/setup-java@v5` with `cache: "maven"` **before** `actions/checkout`, so no `pom.xml` existed yet for setup-java to hash into the Maven cache key. (This is a pre-existing ordering bug — it is *not* caused by #412/#413, which only bumped action versions in other workflows.)

## Fix
Move the checkout step to the top of the job (conventional order), so the working tree — including the poms — is present when `setup-java` resolves the Maven cache. Single-purpose change; no other edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)