### PR TITLE
ci: build & deploy the project webpage as a Docker image (qanary/qanary-webpage)

### DIFF
--- a/.github/workflows/docker-deployment-webpage.yml
+++ b/.github/workflows/docker-deployment-webpage.yml
@@ -1,0 +1,37 @@
+name: Webpage Docker Image CI
+
+# Builds the Qanary project page (the GitHub Pages content in docs/) into a
+# Docker image, pushes it to Docker Hub as qanary/qanary-webpage, and triggers
+# the deployment to the external server via the docker-service-updater. The
+# deployment configuration lives in service_config/service_config.json.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "service_config/build_webpage_image.sh"
+      - ".github/workflows/docker-deployment-webpage.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone local Repository
+        uses: actions/checkout@v7
+
+      - name: Docker Login
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build the webpage Docker image and push to Docker Hub
+        run: bash -c ./service_config/build_webpage_image.sh
+
+      - name: Trigger deployment
+        uses: WSE-research/docker-service-updater@v0.2.1
+        with:
+          api_key: ${{ secrets.API_KEY }}
+          updater_host: ${{ secrets.UPDATER_HOST }}

--- a/docs/.dockerignore
+++ b/docs/.dockerignore
@@ -1,0 +1,6 @@
+# Keep the nginx image to just the served static site.
+Dockerfile
+.dockerignore
+README.md
+.nojekyll
+CNAME

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,20 @@
+# Serves the static Qanary project page (the GitHub Pages content in this folder)
+# as a small nginx image, published to Docker Hub as qanary/qanary-webpage.
+#
+# It listens on container port 40121 to match the port mapping in
+# service_config/service_config.json ("40121:40121").
+#
+# Build context is this docs/ folder, e.g.:
+#   docker build -t qanary/qanary-webpage:latest ./docs
+# (see service_config/build_webpage_image.sh and the
+#  .github/workflows/docker-deployment-webpage.yml workflow).
+FROM nginx:1.27-alpine
+
+# serve on 40121 instead of nginx's default port 80
+RUN sed -i 's/listen *80;/listen 40121;/; s/listen *\[::\]:80;/listen [::]:40121;/' \
+      /etc/nginx/conf.d/default.conf
+
+# the static site (index.html + assets/); see .dockerignore for what is excluded
+COPY . /usr/share/nginx/html
+
+EXPOSE 40121

--- a/service_config/build_images.sh
+++ b/service_config/build_images.sh
@@ -35,3 +35,8 @@ sed -i "s/SECRETS_VIRTUOSO_PASSWORD/${VIRTUOSO_PASSWORD}/g" "$ENV_FILE"
 
 # build and push Docker Images (set -e fails the script if Maven fails)
 mvn -B --settings ./service_config/settings.xml clean install docker:build docker:push -DskipTests -Dgpg.skip=true
+
+# build and push the static project-page image (qanary/qanary-webpage). The same
+# builder powers the standalone webpage deployment workflow
+# (.github/workflows/docker-deployment-webpage.yml).
+bash ./service_config/build_webpage_image.sh

--- a/service_config/build_webpage_image.sh
+++ b/service_config/build_webpage_image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Builds the static Qanary project page (the GitHub Pages content under docs/)
+# into a small nginx image and pushes it to Docker Hub as qanary/qanary-webpage.
+#
+# Reused by both:
+#   - service_config/build_images.sh        (the full deployment build), and
+#   - .github/workflows/docker-deployment-webpage.yml  (standalone webpage deploy)
+#
+# The caller must have authenticated to Docker Hub first (docker/login-action).
+
+set -euo pipefail
+
+IMAGE="qanary/qanary-webpage"
+TAG="${WEBPAGE_IMAGE_TAG:-latest}"
+
+# build from the docs/ folder (its Dockerfile serves the static site via nginx)
+docker build -t "${IMAGE}:${TAG}" ./docs
+
+# push to Docker Hub
+docker push "${IMAGE}:${TAG}"


### PR DESCRIPTION
Containerises the Qanary project page (the static GitHub Pages content in `docs/`) and adds an automated build + deploy pipeline for it, mirroring the existing `docker-deployment.yml` flow.

## What's included

- **`docs/Dockerfile`** (+ `docs/.dockerignore`) — a small `nginx:1.27-alpine` image that serves the static site. It listens on **container port 40121** to match the `"40121:40121"` mapping for `qanary/qanary-webpage` in `service_config/service_config.json`.
- **`service_config/build_webpage_image.sh`** — builds and pushes `qanary/qanary-webpage:latest` (assumes the caller has run `docker login`).
- **`service_config/build_images.sh`** — extended to also build the webpage image (delegates to the script above) alongside the Maven-built images.
- **`.github/workflows/docker-deployment-webpage.yml`** — new workflow: on pushes to `master` that touch `docs/**` (or manual `workflow_dispatch`), it logs in to Docker Hub, builds & pushes `qanary/qanary-webpage`, then triggers the deployment to the external server with `WSE-research/docker-service-updater@v0.2.1` (using the existing `DOCKER_USER` / `DOCKER_PASSWORD` / `API_KEY` / `UPDATER_HOST` secrets). The deployment config is already present in `service_config/service_config.json`.

## Verified locally

`docker build ./docs` succeeds; the running container serves `http://localhost:40121/` → **200** with the correct page, assets load, and excluded files (`Dockerfile`, `README.md`, …) are not served (404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012avagdqqxw8g8wSDi47Yf4