### PR TITLE
fix(webpage): serve on port 80, map as 40121:80

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,8 +1,8 @@
 # Serves the static Qanary project page (the GitHub Pages content in this folder)
 # as a small nginx image, published to Docker Hub as qanary/qanary-webpage.
 #
-# It listens on container port 40121 to match the port mapping in
-# service_config/service_config.json ("40121:40121").
+# It serves on nginx's default port 80; the deployment maps it as "40121:80"
+# (see service_config/service_config.json).
 #
 # Build context is this docs/ folder, e.g.:
 #   docker build -t qanary/qanary-webpage:latest ./docs
@@ -10,11 +10,7 @@
 #  .github/workflows/docker-deployment-webpage.yml workflow).
 FROM nginx:1.27-alpine
 
-# serve on 40121 instead of nginx's default port 80
-RUN sed -i 's/listen *80;/listen 40121;/; s/listen *\[::\]:80;/listen [::]:40121;/' \
-      /etc/nginx/conf.d/default.conf
-
 # the static site (index.html + assets/); see .dockerignore for what is excluded
 COPY . /usr/share/nginx/html
 
-EXPOSE 40121
+EXPOSE 80

--- a/service_config/service_config.json
+++ b/service_config/service_config.json
@@ -11,7 +11,7 @@
     },
     {
       "mode": "dockerfile",
-      "port": "40121:40121",
+      "port": "40121:80",
       "image": "qanary/qanary-webpage",
       "tag": "latest"
     }


### PR DESCRIPTION
Follow-up to #429. Switches the `qanary/qanary-webpage` container from serving on port 40121 to nginx's **default port 80**, and updates the deployment mapping to **`40121:80`**.

The container port and the mapping must agree; previously both were `40121` (`40121:40121`). This moves to the conventional setup — nginx on its default port, no `listen`-directive rewrite — while the externally exposed port stays `40121`.

- `docs/Dockerfile`: drop the `sed` port rewrite; `EXPOSE 80`.
- `service_config/service_config.json`: webpage `port` `40121:40121` → `40121:80`.

**Verified locally:** `docker build ./docs` then `docker run -p 40121:80` → `http://localhost:40121/` returns **200** with the correct page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012avagdqqxw8g8wSDi47Yf4